### PR TITLE
feat(compiler): add substitute func

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,6 @@
 # compiler
 
+[![license](https://img.shields.io/crates/l/gl.svg)](../LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-vela/compiler?status.svg)](https://godoc.org/github.com/go-vela/compiler)
 [![Go Report Card](https://goreportcard.com/badge/go-vela/compiler)](https://goreportcard.com/report/go-vela/compiler)
 [![codecov](https://codecov.io/gh/go-vela/compiler/branch/master/graph/badge.svg)](https://codecov.io/gh/go-vela/compiler)
@@ -34,4 +35,4 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 Copyright (c) 2020 Target Brands, Inc.
 ```
 
-[![license](https://img.shields.io/crates/l/gl.svg)](LICENSE)
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Apache License
+                                Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 

--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -74,6 +74,17 @@ type Engine interface {
 	// for each step in a yaml configuration.
 	ScriptSteps(yaml.StepSlice) (yaml.StepSlice, error)
 
+	// Substitute Compiler Interface Functions
+
+	// SubstituteStages defines a function that replaces every
+	// declared environment variable with it's corresponding
+	// value for each step in every stage in a yaml configuration.
+	SubstituteStages(yaml.StageSlice) (yaml.StageSlice, error)
+	// SubstituteSteps defines a function that replaces every
+	// declared environment variable with it's corresponding
+	// value for each step in a yaml configuration.
+	SubstituteSteps(yaml.StepSlice) (yaml.StepSlice, error)
+
 	// Transform Compiler Interface Functions
 
 	// TransformStages defines a function that converts a yaml

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -62,6 +62,12 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 			return nil, err
 		}
 
+		// inject the substituted environment variables into the stages
+		p.Stages, err = c.SubstituteStages(p.Stages)
+		if err != nil {
+			return nil, err
+		}
+
 		// inject the scripts into the stages
 		p.Stages, err = c.ScriptStages(p.Stages)
 		if err != nil {
@@ -92,6 +98,12 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 
 	// inject the environment variables into the steps
 	p.Steps, err = c.EnvironmentSteps(p.Steps)
+	if err != nil {
+		return nil, err
+	}
+
+	// inject the substituted environment variables into the steps
+	p.Steps, err = c.SubstituteSteps(p.Steps)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/native/substitute.go
+++ b/compiler/native/substitute.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package native
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/yaml"
+
+	"github.com/drone/envsubst"
+
+	types "github.com/go-vela/types/yaml"
+)
+
+// SubstituteStages replaces every declared environment
+// variable with it's corresponding value for each step
+// in every stage in a yaml configuration.
+func (c *client) SubstituteStages(s types.StageSlice) (types.StageSlice, error) {
+	// iterate through all stages
+	for _, stage := range s {
+		// inject the scripts into the steps for the stage
+		steps, err := c.SubstituteSteps(stage.Steps)
+		if err != nil {
+			return nil, err
+		}
+
+		stage.Steps = steps
+	}
+
+	return s, nil
+}
+
+// SubstituteSteps replaces every declared environment
+// variable with it's corresponding value for each step
+// in a yaml configuration.
+func (c *client) SubstituteSteps(s types.StepSlice) (types.StepSlice, error) {
+	// iterate through all steps
+	for _, step := range s {
+		// marshal step configuration
+		body, err := yaml.Marshal(step)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal configuration: %v", err)
+		}
+
+		// create substitute function
+		subFunc := func(name string) string {
+			env := step.Environment[name]
+			if strings.Contains(env, "\n") {
+				env = fmt.Sprintf("%q", env)
+			}
+
+			return env
+		}
+
+		// substitute the environment variables
+		subStep, err := envsubst.Eval(string(body), subFunc)
+		if err != nil {
+			return nil, fmt.Errorf("unable to substitute environment variables: %v", err)
+		}
+
+		// unmarshal step configuration
+		err = yaml.Unmarshal([]byte(subStep), step)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal configuration: %v", err)
+		}
+	}
+
+	return s, nil
+}

--- a/compiler/native/substitute_test.go
+++ b/compiler/native/substitute_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package native
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/yaml"
+
+	"github.com/urfave/cli"
+
+	"github.com/kr/pretty"
+)
+
+func TestNative_SubstituteStages(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	c := cli.NewContext(nil, set, nil)
+
+	s := yaml.StageSlice{
+		{
+			Name: "simple",
+			Steps: yaml.StepSlice{
+				{
+					Commands:    []string{"echo ${FOO}", "echo $${BAR}"},
+					Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+					Image:       "alpine:latest",
+					Name:        "simple",
+					Pull:        true,
+				},
+			},
+		},
+		{
+			Name: "advanced",
+			Steps: yaml.StepSlice{
+				{
+					Commands:    []string{"echo ${COMPLEX}"},
+					Environment: map[string]string{"COMPLEX": "{\"hello\":\n  \"world\"}"},
+					Image:       "alpine:latest",
+					Name:        "advanced",
+					Pull:        true,
+				},
+			},
+		},
+	}
+
+	want := yaml.StageSlice{
+		{
+			Name: "simple",
+			Steps: yaml.StepSlice{
+				{
+					Commands:    []string{"echo baz", "echo ${BAR}"},
+					Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+					Image:       "alpine:latest",
+					Name:        "simple",
+					Pull:        true,
+				},
+			},
+		},
+		{
+			Name: "advanced",
+			Steps: yaml.StepSlice{
+				{
+					Commands:    []string{"echo \"{\\\"hello\\\":\\n  \\\"world\\\"}\""},
+					Environment: map[string]string{"COMPLEX": "{\"hello\":\n  \"world\"}"},
+					Image:       "alpine:latest",
+					Name:        "advanced",
+					Pull:        true,
+				},
+			},
+		},
+	}
+
+	// run test
+	compiler, err := New(c)
+	if err != nil {
+		t.Errorf("Creating compiler returned err: %v", err)
+	}
+
+	got, err := compiler.SubstituteStages(s)
+	if err != nil {
+		t.Errorf("SubstituteStages returned err: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SubstituteStages is %v, want %v", got, want)
+	}
+}
+
+func TestNative_SubstituteSteps(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	c := cli.NewContext(nil, set, nil)
+
+	p := yaml.StepSlice{
+		{
+			Commands:    []string{"echo ${FOO}", "echo $${BAR}"},
+			Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+			Image:       "alpine:latest",
+			Name:        "simple",
+			Pull:        true,
+		},
+		{
+			Commands:    []string{"echo ${COMPLEX}"},
+			Environment: map[string]string{"COMPLEX": "{\"hello\":\n  \"world\"}"},
+			Image:       "alpine:latest",
+			Name:        "advanced",
+			Pull:        true,
+		},
+	}
+
+	want := yaml.StepSlice{
+		{
+			Commands:    []string{"echo baz", "echo ${BAR}"},
+			Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+			Image:       "alpine:latest",
+			Name:        "simple",
+			Pull:        true,
+		},
+		{
+			Commands:    []string{"echo \"{\\\"hello\\\":\\n  \\\"world\\\"}\""},
+			Environment: map[string]string{"COMPLEX": "{\"hello\":\n  \"world\"}"},
+			Image:       "alpine:latest",
+			Name:        "advanced",
+			Pull:        true,
+		},
+	}
+
+	// run test
+	compiler, err := New(c)
+	if err != nil {
+		t.Errorf("Creating compiler returned err: %v", err)
+	}
+
+	got, err := compiler.SubstituteSteps(p)
+	if err != nil {
+		t.Errorf("SubstituteSteps returned err: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		pretty.Ldiff(t, got, want)
+		t.Errorf("SubstituteSteps is %v, want %v", got, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/drone/envsubst v1.0.2
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-gonic/gin v1.5.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
@@ -19,7 +20,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
+	github.com/kr/pretty v0.1.0
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/drone/envsubst v1.0.2 h1:dpYLMAspQHW0a8dZpLRKe9jCNvIGZPhCPrycZzIHdqo=
+github.com/drone/envsubst v1.0.2/go.mod h1:bkZbnc/2vh1M12Ecn7EYScpI4YGYU0etwLJICOWi8Z0=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -40,6 +42,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v24 v24.0.1 h1:KCt1LjMJEey1qvPXxa9SjaWxwTsCWSq6p2Ju57UR4Q4=


### PR DESCRIPTION
The reason this PR contains the `feature` label is because it's net-new functionality that is being added to the compiler. Previously our string substitution was handled in the `go-vela/worker` but after some rework, it's being moved up to the compiler.

The reason this PR contains the `bug` label is because it also will help address a regression bug that creeped back up preventing users to be able to substitute environment variables. Essentially, we'll be removing the code that substituted those environment variables from the worker and instead having that become functionality of the compiler.

[This thread](https://target-tts.slack.com/archives/CN8N93Q6L/p1585929272244400) contains more details.

The checks are failing for the test coverage but I'd like to address that in a separate PR 👍 