### PR TITLE
fix(environment): populating BUILD_TAG variable

### DIFF
--- a/compiler/native/environment.go
+++ b/compiler/native/environment.go
@@ -125,7 +125,7 @@ func environment(b *library.Build, m *types.Metadata, r *library.Repo, u *librar
 
 	// set tag environment variable if proper build event
 	if b.GetEvent() == constants.EventTag {
-		env["BUILD_TAG"] = strings.Split(b.GetRef(), "/")[2]
+		env["BUILD_TAG"] = strings.SplitN(b.GetRef(), "refs/tags/", 2)[1]
 	}
 
 	// populate environment variables from metadata


### PR DESCRIPTION
Fixes https://github.com/go-vela/compiler/issues/47