### PR TITLE
fix(substitute): skip unfound env vars

### DIFF
--- a/compiler/native/substitute.go
+++ b/compiler/native/substitute.go
@@ -47,8 +47,17 @@ func (c *client) SubstituteSteps(s types.StepSlice) (types.StepSlice, error) {
 
 		// create substitute function
 		subFunc := func(name string) string {
-			env := step.Environment[name]
+			// check for the environment variable
+			env, ok := step.Environment[name]
+			if !ok {
+				// return the original declaration if
+				// the environment variable isn't found
+				return fmt.Sprintf("${%s}", name)
+			}
+
+			// check for a new line
 			if strings.Contains(env, "\n") {
+				// escape the environment variable
 				env = fmt.Sprintf("%q", env)
 			}
 

--- a/compiler/native/substitute_test.go
+++ b/compiler/native/substitute_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/go-vela/types/yaml"
 
 	"github.com/urfave/cli/v2"
-
-	"github.com/kr/pretty"
 )
 
 func TestNative_SubstituteStages(t *testing.T) {
@@ -46,6 +44,18 @@ func TestNative_SubstituteStages(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "not_found",
+			Steps: yaml.StepSlice{
+				{
+					Commands:    []string{"echo $NOT_FOUND", "echo ${NOT_FOUND}", "echo $${NOT_FOUND}"},
+					Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+					Image:       "alpine:latest",
+					Name:        "not_found",
+					Pull:        true,
+				},
+			},
+		},
 	}
 
 	want := yaml.StageSlice{
@@ -69,6 +79,18 @@ func TestNative_SubstituteStages(t *testing.T) {
 					Environment: map[string]string{"COMPLEX": "{\"hello\":\n  \"world\"}"},
 					Image:       "alpine:latest",
 					Name:        "advanced",
+					Pull:        true,
+				},
+			},
+		},
+		{
+			Name: "not_found",
+			Steps: yaml.StepSlice{
+				{
+					Commands:    []string{"echo $NOT_FOUND", "echo ${NOT_FOUND}", "echo ${NOT_FOUND}"},
+					Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+					Image:       "alpine:latest",
+					Name:        "not_found",
 					Pull:        true,
 				},
 			},
@@ -156,7 +178,6 @@ func TestNative_SubstituteSteps(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(got, want) {
-		pretty.Ldiff(t, got, want)
 		t.Errorf("SubstituteSteps is %v, want %v", got, want)
 	}
 }

--- a/compiler/native/substitute_test.go
+++ b/compiler/native/substitute_test.go
@@ -111,6 +111,13 @@ func TestNative_SubstituteSteps(t *testing.T) {
 			Name:        "advanced",
 			Pull:        true,
 		},
+		{
+			Commands:    []string{"echo $NOT_FOUND", "echo ${NOT_FOUND}", "echo $${NOT_FOUND}"},
+			Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+			Image:       "alpine:latest",
+			Name:        "not_found",
+			Pull:        true,
+		},
 	}
 
 	want := yaml.StepSlice{
@@ -126,6 +133,13 @@ func TestNative_SubstituteSteps(t *testing.T) {
 			Environment: map[string]string{"COMPLEX": "{\"hello\":\n  \"world\"}"},
 			Image:       "alpine:latest",
 			Name:        "advanced",
+			Pull:        true,
+		},
+		{
+			Commands:    []string{"echo $NOT_FOUND", "echo ${NOT_FOUND}", "echo ${NOT_FOUND}"},
+			Environment: map[string]string{"FOO": "baz", "BAR": "baz"},
+			Image:       "alpine:latest",
+			Name:        "not_found",
 			Pull:        true,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/kr/pretty v0.1.0
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect


### PR DESCRIPTION
This bug prevents the injection of environment variables that don't already exist for a step. The current behavior will substitute the environment variable for an empty string causing the compiler to error out:

```
error:unable to process webhook: failed to compile pipeline configuration for vela/server: unable to unmarshal configuration: yaml: line <line number>: did not find expected node content
```

To see an example, I've attached a **redacted** example of a pipeline we use internally:

```yaml
version: "1"

steps:

  - name: build
    image: <registry>/vela-plugins/docker:1
    pull: true
    parameters:
      dry_run: true
      registry: <registry>
      repo: <registry>/<repo>
      tags:
        - latest
        - "${BUILD_COMMIT:0:8}" # for tagged releases
        - "b${BUILD_NUMBER}-${BUILD_COMMIT:0:8}"

  - name: publish
    image: <registry>/vela-plugins/docker:1
    pull: true
    parameters:
      registry: <registry>
      repo: <registry>/<repo>
      tags:
        - latest
        - "${BUILD_COMMIT:0:8}" # for tagged releases
        - "b${BUILD_NUMBER}-${BUILD_COMMIT:0:8}"
    ruleset:
      branch: master
      event: push
    secrets: [ docker_username, docker_password ]

  - name: vanity
    image: <registry>/vela-plugins/docker-promotion:1
    pull: true
    parameters:
      source_repo: <registry>/vela/server
      source_tag: "${BUILD_COMMIT:0:8}"
      target_tags:
        - "${BUILD_TAG}"
        - "${BUILD_TAG:0:4}"
    ruleset:
      event: tag
    secrets: [ registry_username, registry_password ]
```

This pipeline is always failing because the compiler is attempting to substitute the environment variables for the `vanity` step, but it's always failing, unless the build is for a `tag` event, because the `BUILD_TAG` environment variable is only populated on a `tag` event.