### PR TITLE
fix: enable running step with env or secrets

### DIFF
--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -82,9 +82,9 @@ func validateStages(s yaml.StageSlice) error {
 			}
 
 			if len(step.Commands) == 0 && len(step.Environment) == 0 &&
-				len(step.Parameters) == 0 && len(step.Template.Name) == 0 &&
-				!step.Detach {
-				return fmt.Errorf("no commands, environment, parameters or template provided for step %s for stage %s", step.Name, stage.Name)
+				len(step.Parameters) == 0 && len(step.Secrets) == 0 &&
+				len(step.Template.Name) == 0 && !step.Detach {
+				return fmt.Errorf("no commands, environment, parameters, secrets or template provided for step %s for stage %s", step.Name, stage.Name)
 			}
 		}
 	}
@@ -105,9 +105,9 @@ func validateSteps(s yaml.StepSlice) error {
 		}
 
 		if len(step.Commands) == 0 && len(step.Environment) == 0 &&
-			len(step.Parameters) == 0 && len(step.Template.Name) == 0 &&
-			!step.Detach {
-			return fmt.Errorf("no commands, environment, parameters or template provided for step %s", step.Name)
+			len(step.Parameters) == 0 && len(step.Secrets) == 0 &&
+			len(step.Template.Name) == 0 && !step.Detach {
+			return fmt.Errorf("no commands, environment, parameters, secrets or template provided for step %s", step.Name)
 		}
 	}
 

--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -81,9 +81,10 @@ func validateStages(s yaml.StageSlice) error {
 				return fmt.Errorf("no image or template provided for step %s for stage %s", step.Name, stage.Name)
 			}
 
-			if len(step.Commands) == 0 && len(step.Parameters) == 0 &&
-				len(step.Template.Name) == 0 && !step.Detach {
-				return fmt.Errorf("no commands or parameters or template provided for step %s for stage %s", step.Name, stage.Name)
+			if len(step.Commands) == 0 && len(step.Environment) == 0 &&
+				len(step.Parameters) == 0 && len(step.Template.Name) == 0 &&
+				!step.Detach {
+				return fmt.Errorf("no commands, environment, parameters or template provided for step %s for stage %s", step.Name, stage.Name)
 			}
 		}
 	}
@@ -103,9 +104,10 @@ func validateSteps(s yaml.StepSlice) error {
 			return fmt.Errorf("no image or template provided for step %s", step.Name)
 		}
 
-		if len(step.Commands) == 0 && len(step.Parameters) == 0 &&
-			len(step.Template.Name) == 0 && !step.Detach {
-			return fmt.Errorf("no commands or parameters or template provided for step %s", step.Name)
+		if len(step.Commands) == 0 && len(step.Environment) == 0 &&
+			len(step.Parameters) == 0 && len(step.Template.Name) == 0 &&
+			!step.Detach {
+			return fmt.Errorf("no commands, environment, parameters or template provided for step %s", step.Name)
 		}
 	}
 


### PR DESCRIPTION
Today, **we don't allow** someone to run a step in Vela if they **haven't met our requirements**.

However, it appears **our requirements were too strict** because some people have tried to run a plugin that **only requires environment variables or secrets** to run.

We've also seen one specific plugin that uses a YAML file to source its configuration from.

To workaround this, we've seen several customers provide an "empty" `parameters` block:

```
steps:
  - name: example
    image: some-custom-plugin
    environment:
      FOO: bar
    secrets: [ superSecret ]
    parameters:
      empty:
```

This PR changes that to allow someone to provide a plugin that only requires environment variables or secrets to run inside Vela without having to use a "hack" with `parameters`.