### PR TITLE
feat: use repo default branch for template resolution

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -181,6 +181,7 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 // errorHandler ensures the error contains the number of request attempts.
 func errorHandler(resp *http.Response, err error, attempts int) (*http.Response, error) {
 	if err != nil {
+		// nolint:lll // detailed error message
 		err = fmt.Errorf("giving up connecting to modification endpoint after %d attempts due to: %v", attempts, err)
 	}
 
@@ -188,6 +189,7 @@ func errorHandler(resp *http.Response, err error, attempts int) (*http.Response,
 }
 
 // modifyConfig sends the configuration to external http endpoint for modification.
+// nolint:lll // parameter struct references push line limit
 func (c *client) modifyConfig(build *yaml.Build, libraryBuild *library.Build, repo *library.Repo) (*yaml.Build, error) {
 	// create request to send to endpoint
 	modReq := &ModifyRequest{

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -55,7 +55,7 @@ func (c *client) ExpandSteps(s yaml.StepSlice, tmpls map[string]*yaml.Template) 
 		}
 
 		// parse source from template
-		src, err := c.Github.Parse(tmpl.Source)
+		src, err := c.Github.Parse(tmpl.Source, c.repo.GetBranch())
 		if err != nil {
 			return yaml.StepSlice{}, fmt.Errorf("invalid template source provided for %s: %v", step.Template.Name, err)
 		}

--- a/registry/github/parse.go
+++ b/registry/github/parse.go
@@ -12,8 +12,11 @@ import (
 	"github.com/goware/urlx"
 )
 
-// Parse creates the registry source object from a template path.
-func (c *client) Parse(path string) (*registry.Source, error) {
+const defaultRef = "main"
+
+// Parse creates the registry source object from
+// a template path and default branch.
+func (c *client) Parse(path string, defaultBranch string) (*registry.Source, error) {
 	// parse the path provided
 	//
 	// goware/urlx is used over net/url because it is more consistent for parsing
@@ -33,8 +36,13 @@ func (c *client) Parse(path string) (*registry.Source, error) {
 	// * <org>/<repo>/<path>/<to>/<filename>
 	parts := strings.SplitN(u.Path, "/", 3)
 
-	// set the default reference to master
-	ref := "master"
+	// use the fallback default reference
+	ref := defaultRef
+
+	// override with supplied defaultBranch
+	if len(defaultBranch) > 0 {
+		ref = defaultBranch
+	}
 
 	// check for reference provided in filename:
 	// * <org>/<repo>/<filename>@<reference>

--- a/registry/github/parse.go
+++ b/registry/github/parse.go
@@ -16,7 +16,7 @@ const defaultRef = "main"
 
 // Parse creates the registry source object from
 // a template path and default branch.
-func (c *client) Parse(path string, defaultBranch string) (*registry.Source, error) {
+func (c *client) Parse(path, defaultBranch string) (*registry.Source, error) {
 	// parse the path provided
 	//
 	// goware/urlx is used over net/url because it is more consistent for parsing

--- a/registry/github/parse_test.go
+++ b/registry/github/parse_test.go
@@ -26,6 +26,39 @@ func TestGithub_Parse(t *testing.T) {
 		Org:  "github",
 		Repo: "octocat",
 		Name: "template.yml",
+		Ref:  "main",
+	}
+
+	// run test
+	c, err := New(s.URL, "")
+	if err != nil {
+		t.Errorf("Creating client returned err: %v", err)
+	}
+
+	path := "github.example.com/github/octocat/template.yml"
+	defaultBranch := ""
+
+	got, err := c.Parse(path, defaultBranch)
+	if err != nil {
+		t.Errorf("Parse returned err: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Parse is %v, want %v", got, want)
+	}
+}
+
+func TestGithub_ParseWithDefaultBranch(t *testing.T) {
+	// setup mock server
+	s := httptest.NewServer(http.NotFoundHandler())
+	defer s.Close()
+
+	// setup types
+	want := &registry.Source{
+		Host: "github.example.com",
+		Org:  "github",
+		Repo: "octocat",
+		Name: "template.yml",
 		Ref:  "master",
 	}
 
@@ -36,7 +69,9 @@ func TestGithub_Parse(t *testing.T) {
 	}
 
 	path := "github.example.com/github/octocat/template.yml"
-	got, err := c.Parse(path)
+	defaultBranch := "master"
+
+	got, err := c.Parse(path, defaultBranch)
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -45,7 +80,6 @@ func TestGithub_Parse(t *testing.T) {
 		t.Errorf("Parse is %v, want %v", got, want)
 	}
 }
-
 func TestGithub_Parse_Custom(t *testing.T) {
 	// setup mock server
 	s := httptest.NewServer(http.NotFoundHandler())
@@ -67,7 +101,9 @@ func TestGithub_Parse_Custom(t *testing.T) {
 	}
 
 	path := "github.example.com/github/octocat/path/to/template.yml@test"
-	got, err := c.Parse(path)
+	defaultBranch := ""
+
+	got, err := c.Parse(path, defaultBranch)
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -103,7 +139,9 @@ func TestGithub_Parse_Full(t *testing.T) {
 	}
 
 	path := fmt.Sprintf("%s/%s", s.URL, "github/octocat/template.yml@test")
-	got, err := c.Parse(path)
+	defaultBranch := ""
+
+	got, err := c.Parse(path, defaultBranch)
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -124,7 +162,7 @@ func TestGithub_Parse_Invalid(t *testing.T) {
 		t.Errorf("Creating client returned err: %v", err)
 	}
 
-	got, err := c.Parse("!@#$%^&*()")
+	got, err := c.Parse("!@#$%^&*()", "")
 	if err == nil {
 		t.Errorf("Parse should have returned err")
 	}
@@ -150,7 +188,7 @@ func TestGithub_Parse_Hostname(t *testing.T) {
 		Org:  "github",
 		Repo: "octocat",
 		Name: "template.yml",
-		Ref:  "master",
+		Ref:  "main",
 	}
 
 	// run test
@@ -160,7 +198,9 @@ func TestGithub_Parse_Hostname(t *testing.T) {
 	}
 
 	path := fmt.Sprintf("%s/%s", u.Hostname(), "github/octocat/template.yml")
-	got, err := c.Parse(path)
+	defaultBranch := ""
+
+	got, err := c.Parse(path, defaultBranch)
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -186,7 +226,7 @@ func TestGithub_Parse_Path(t *testing.T) {
 		Org:  "github",
 		Repo: "octocat",
 		Name: "path/to/template.yml",
-		Ref:  "master",
+		Ref:  "main",
 	}
 
 	// run test
@@ -196,7 +236,9 @@ func TestGithub_Parse_Path(t *testing.T) {
 	}
 
 	path := fmt.Sprintf("%s/%s", s.URL, "github/octocat/path/to/template.yml")
-	got, err := c.Parse(path)
+	defaultBranch := ""
+
+	got, err := c.Parse(path, defaultBranch)
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -10,8 +10,9 @@ import "github.com/go-vela/types/library"
 // with the different supported template registries.
 type Service interface {
 	// Parse defines a function that creates the
-	// registry source object from a template path.
-	Parse(string) (*Source, error)
+	// registry source object from a template path
+	// and default branch.
+	Parse(string, string) (*Source, error)
 
 	// Template defines a function that captures the
 	// templated pipeline configuration from a repo.


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/134

See the issue for more details. The proposed changes should result in Vela pulling from the default branch that Vela is aware of from when the Repo was added or hook for the repo was created.