### PR TITLE
enhance(templates): auto inject platform vars for golang

### DIFF
--- a/template/native/convert.go
+++ b/template/native/convert.go
@@ -1,0 +1,39 @@
+package native
+
+import (
+	"github.com/go-vela/types/raw"
+	"strings"
+)
+
+// convertPlatformVars takes the platform injected variables
+// within the step environment block and modifies them to be returned
+// within the template
+func convertPlatformVars(slice raw.StringSliceMap) raw.StringSliceMap {
+	envs := make(map[string]string)
+	for key, value := range slice {
+		key = strings.ToLower(key)
+		if strings.HasPrefix(key, "vela_") {
+			envs[strings.TrimPrefix(key, "vela_")] = value
+		}
+	}
+
+	return envs
+}
+
+type funcHandler struct {
+	envs raw.StringSliceMap
+}
+
+// returnPlatformVar returns the value of the platform
+// variable if it exists within the map
+func (h funcHandler) returnPlatformVar(input string) string {
+	input = strings.ToLower(input)
+	input = strings.TrimPrefix(input, "vela_")
+	// check if key exists within map
+	if _, ok := h.envs[input]; ok {
+		// return value if exists
+		return h.envs[input]
+	}
+	// return empty string if not exists
+	return ""
+}

--- a/template/native/convert.go
+++ b/template/native/convert.go
@@ -1,8 +1,9 @@
 package native
 
 import (
-	"github.com/go-vela/types/raw"
 	"strings"
+
+	"github.com/go-vela/types/raw"
 )
 
 // convertPlatformVars takes the platform injected variables

--- a/template/native/convert.go
+++ b/template/native/convert.go
@@ -8,7 +8,7 @@ import (
 
 // convertPlatformVars takes the platform injected variables
 // within the step environment block and modifies them to be returned
-// within the template
+// within the template.
 func convertPlatformVars(slice raw.StringSliceMap) raw.StringSliceMap {
 	envs := make(map[string]string)
 	for key, value := range slice {
@@ -26,7 +26,7 @@ type funcHandler struct {
 }
 
 // returnPlatformVar returns the value of the platform
-// variable if it exists within the map
+// variable if it exists within the environment map.
 func (h funcHandler) returnPlatformVar(input string) string {
 	input = strings.ToLower(input)
 	input = strings.TrimPrefix(input, "vela_")

--- a/template/native/convert_test.go
+++ b/template/native/convert_test.go
@@ -1,9 +1,10 @@
 package native
 
 import (
-	"github.com/go-vela/types/raw"
 	"reflect"
 	"testing"
+
+	"github.com/go-vela/types/raw"
 )
 
 func Test_convertPlatformVars(t *testing.T) {

--- a/template/native/convert_test.go
+++ b/template/native/convert_test.go
@@ -1,0 +1,119 @@
+package native
+
+import (
+	"github.com/go-vela/types/raw"
+	"reflect"
+	"testing"
+)
+
+func Test_convertPlatformVars(t *testing.T) {
+	tests := []struct {
+		name string
+		args raw.StringSliceMap
+		want raw.StringSliceMap
+	}{
+		{
+			name: "with all vela prefixed vars",
+			args: raw.StringSliceMap{
+				"VELA_BUILD_AUTHOR":   "octocat",
+				"VELA_REPO_FULL_NAME": "go-vela/hello-world",
+				"VELA_USER_ADMIN":     "true",
+				"VELA_WORKSPACE":      "/vela/src/github.com/go-vela/hello-world",
+			},
+			want: raw.StringSliceMap{"build_author": "octocat", "repo_full_name": "go-vela/hello-world", "user_admin": "true", "workspace": "/vela/src/github.com/go-vela/hello-world"},
+		},
+		{
+			name: "with combination of vela and user vars",
+			args: raw.StringSliceMap{
+				"VELA_BUILD_AUTHOR":   "octocat",
+				"VELA_REPO_FULL_NAME": "go-vela/hello-world",
+				"FOO_VAR1":            "test1",
+				"BAR_VAR1":            "test2",
+			},
+			want: raw.StringSliceMap{"build_author": "octocat", "repo_full_name": "go-vela/hello-world"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := convertPlatformVars(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertPlatformVars() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_funcHandler_returnPlatformVar(t *testing.T) {
+	type fields struct {
+		envs raw.StringSliceMap
+	}
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "existing platform var without prefix (lowercase)",
+			fields: fields{
+				envs: raw.StringSliceMap{
+					"build_author": "octocat",
+				},
+			},
+			args: args{input: "build_author"},
+			want: "octocat",
+		},
+		{
+			name: "existing platform var without prefix (uppercase)",
+			fields: fields{
+				envs: raw.StringSliceMap{
+					"build_author": "octocat",
+				},
+			},
+			args: args{input: "BUILD_AUTHOR"},
+			want: "octocat",
+		},
+		{
+			name: "existing platform var with prefix (lowercase)",
+			fields: fields{
+				envs: raw.StringSliceMap{
+					"build_author": "octocat",
+				},
+			},
+			args: args{input: "vela_build_author"},
+			want: "octocat",
+		},
+		{
+			name: "existing platform var with prefix (uppercase)",
+			fields: fields{
+				envs: raw.StringSliceMap{
+					"build_author": "octocat",
+				},
+			},
+			args: args{input: "VELA_BUILD_AUTHOR"},
+			want: "octocat",
+		},
+		{
+			name: "non existent var",
+			fields: fields{
+				envs: raw.StringSliceMap{
+					"build_author": "octocat",
+				},
+			},
+			args: args{input: "foo"},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := funcHandler{
+				envs: tt.fields.envs,
+			}
+			if got := h.returnPlatformVar(tt.args.input); got != tt.want {
+				t.Errorf("returnPlatformVar() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/template/native/render.go
+++ b/template/native/render.go
@@ -17,10 +17,15 @@ func Render(tmpl string, s *types.Step) (types.StepSlice, error) {
 	buffer := new(bytes.Buffer)
 	config := new(types.Build)
 
+	velaFuncs := funcHandler{envs: convertPlatformVars(s.Environment)}
+	templateFuncMap := map[string]interface{}{
+		"vela": velaFuncs.returnPlatformVar,
+	}
+
 	// parse the template with Masterminds/sprig functions
 	//
 	// https://pkg.go.dev/github.com/Masterminds/sprig?tab=doc#TxtFuncMap
-	t, err := template.New(s.Name).Funcs(sprig.TxtFuncMap()).Parse(tmpl)
+	t, err := template.New(s.Name).Funcs(sprig.TxtFuncMap()).Funcs(templateFuncMap).Parse(tmpl)
 	if err != nil {
 		return types.StepSlice{}, fmt.Errorf("unable to parse template %s: %v", s.Template.Name, err)
 	}

--- a/template/native/render_test.go
+++ b/template/native/render_test.go
@@ -5,8 +5,9 @@
 package native
 
 import (
+	"github.com/go-vela/types/raw"
+	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
-	"reflect"
 	"testing"
 
 	goyaml "gopkg.in/yaml.v2"
@@ -14,205 +15,69 @@ import (
 	"github.com/go-vela/types/yaml"
 )
 
-func TestNative_Render_Basic(t *testing.T) {
-	// setup types
-	sFile, _ := ioutil.ReadFile("testdata/basic/step.yml")
-	b := &yaml.Build{}
-	_ = goyaml.Unmarshal(sFile, b)
-
-	wFile, _ := ioutil.ReadFile("testdata/basic/want.yml")
-	w := &yaml.Build{}
-	_ = goyaml.Unmarshal(wFile, w)
-
-	want := w.Steps
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/basic/tmpl.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
+func TestNative_Render(t *testing.T) {
+	type args struct {
+		velaFile     string
+		templateFile string
 	}
-
-	got, err := Render(string(tmpl), b.Steps[0])
-	if err != nil {
-		t.Errorf("Render returned err: %v", err)
+	tests := []struct {
+		name     string
+		args     args
+		wantFile string
+		wantErr  bool
+	}{
+		{"basic", args{velaFile: "testdata/basic/step.yml", templateFile: "testdata/basic/tmpl.yml"}, "testdata/basic/want.yml", false},
+		{"multiline", args{velaFile: "testdata/multiline/step.yml", templateFile: "testdata/multiline/tmpl.yml"}, "testdata/multiline/want.yml", false},
+		{"conditional match", args{velaFile: "testdata/conditional/step.yml", templateFile: "testdata/conditional/tmpl.yml"}, "testdata/conditional/want.yml", false},
+		{"loop map", args{velaFile: "testdata/loop_map/step.yml", templateFile: "testdata/loop_map/tmpl.yml"}, "testdata/loop_map/want.yml", false},
+		{"loop slice", args{velaFile: "testdata/loop_slice/step.yml", templateFile: "testdata/loop_slice/tmpl.yml"}, "testdata/loop_slice/want.yml", false},
+		{"platform vars", args{velaFile: "testdata/with_vars_plat/step.yml", templateFile: "testdata/with_vars_plat/tmpl.yml"}, "testdata/with_vars_plat/want.yml", false},
+		{"invalid template", args{velaFile: "testdata/basic/step.yml", templateFile: "testdata/invalid_template.yml"}, "", true},
+		{"invalid variable", args{velaFile: "testdata/basic/step.yml", templateFile: "testdata/invalid_variables.yml"}, "", true},
+		{"invalid yml", args{velaFile: "testdata/basic/step.yml", templateFile: "testdata/invalid.yml"}, "", true},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sFile, err := ioutil.ReadFile(tt.args.velaFile)
+			if err != nil {
+				t.Error(err)
+			}
+			b := &yaml.Build{}
+			err = goyaml.Unmarshal(sFile, b)
+			if err != nil {
+				t.Error(err)
+			}
+			b.Steps[0].Environment = raw.StringSliceMap{
+				"VELA_REPO_FULL_NAME": "octocat/hello-world",
+			}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
-	}
-}
+			tmpl, err := ioutil.ReadFile(tt.args.templateFile)
+			if err != nil {
+				t.Error(err)
+			}
 
-func TestNative_Render_Multiline(t *testing.T) {
-	// setup types
-	sFile, _ := ioutil.ReadFile("testdata/multiline/step.yml")
-	b := &yaml.Build{}
-	_ = goyaml.Unmarshal(sFile, b)
+			got, err := Render(string(tmpl), b.Steps[0])
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Render() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 
-	wFile, _ := ioutil.ReadFile("testdata/multiline/want.yml")
-	w := &yaml.Build{}
-	_ = goyaml.Unmarshal(wFile, w)
+			if tt.wantErr != true {
+				wFile, err := ioutil.ReadFile(tt.wantFile)
+				if err != nil {
+					t.Error(err)
+				}
+				w := &yaml.Build{}
+				err = goyaml.Unmarshal(wFile, w)
+				if err != nil {
+					t.Error(err)
+				}
+				want := w.Steps
 
-	want := w.Steps
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/multiline/tmpl.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
-	}
-
-	got, err := Render(string(tmpl), b.Steps[0])
-	if err != nil {
-		t.Errorf("Render returned err: %v", err)
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
-	}
-}
-
-func TestNative_Render_Conditional_Match(t *testing.T) {
-	// setup types
-	sFile, _ := ioutil.ReadFile("testdata/conditional/step.yml")
-	b := &yaml.Build{}
-	_ = goyaml.Unmarshal(sFile, b)
-
-	wFile, _ := ioutil.ReadFile("testdata/conditional/want.yml")
-	w := &yaml.Build{}
-	_ = goyaml.Unmarshal(wFile, w)
-
-	want := w.Steps
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/conditional/tmpl.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
-	}
-
-	got, err := Render(string(tmpl), b.Steps[0])
-	if err != nil {
-		t.Errorf("Render returned err: %v", err)
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
-	}
-}
-
-func TestNative_Render_Loop_Map(t *testing.T) {
-	// setup types
-	sFile, _ := ioutil.ReadFile("testdata/loop_map/step.yml")
-	b := &yaml.Build{}
-	_ = goyaml.Unmarshal(sFile, b)
-
-	wFile, _ := ioutil.ReadFile("testdata/loop_map/want.yml")
-	w := &yaml.Build{}
-	_ = goyaml.Unmarshal(wFile, w)
-
-	want := w.Steps
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/loop_map/tmpl.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
-	}
-
-	got, err := Render(string(tmpl), b.Steps[0])
-	if err != nil {
-		t.Errorf("Render returned err: %v", err)
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
-	}
-}
-
-func TestNative_Render_Loop_Slice(t *testing.T) {
-	// setup types
-	sFile, _ := ioutil.ReadFile("testdata/loop_slice/step.yml")
-	b := &yaml.Build{}
-	_ = goyaml.Unmarshal(sFile, b)
-
-	wFile, _ := ioutil.ReadFile("testdata/loop_slice/want.yml")
-	w := &yaml.Build{}
-	_ = goyaml.Unmarshal(wFile, w)
-
-	want := w.Steps
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/loop_slice/tmpl.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
-	}
-
-	got, err := Render(string(tmpl), b.Steps[0])
-	if err != nil {
-		t.Errorf("Render returned err: %v", err)
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
-	}
-}
-
-func TestNative_Render_InvalidTemplate(t *testing.T) {
-	// setup types
-	want := yaml.StepSlice{}
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/invalid_template.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
-	}
-
-	got, err := Render(string(tmpl), &yaml.Step{})
-
-	if err == nil {
-		t.Errorf("Render should have returned err")
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
-	}
-}
-
-func TestNative_Render_InvalidVariables(t *testing.T) {
-	// setup types
-	want := yaml.StepSlice{}
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/invalid_variables.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
-	}
-
-	got, err := Render(string(tmpl), &yaml.Step{})
-
-	if err == nil {
-		t.Errorf("Render should have returned err")
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
-	}
-}
-
-func TestNative_Render_InvalidYml(t *testing.T) {
-	// setup types
-	want := yaml.StepSlice{}
-
-	// run test
-	tmpl, err := ioutil.ReadFile("testdata/invalid.yml")
-	if err != nil {
-		t.Errorf("Reading file returned err: %v", err)
-	}
-
-	got, err := Render(string(tmpl), &yaml.Step{})
-
-	if err == nil {
-		t.Errorf("Render should have returned err")
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Render is %v, want %v", got, want)
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
 	}
 }

--- a/template/native/render_test.go
+++ b/template/native/render_test.go
@@ -5,10 +5,11 @@
 package native
 
 import (
-	"github.com/go-vela/types/raw"
-	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
 	"testing"
+
+	"github.com/go-vela/types/raw"
+	"github.com/google/go-cmp/cmp"
 
 	goyaml "gopkg.in/yaml.v2"
 

--- a/template/native/testdata/with_vars_plat/step.yml
+++ b/template/native/testdata/with_vars_plat/step.yml
@@ -1,0 +1,4 @@
+steps:
+  - name: sample
+    template:
+      name: golang

--- a/template/native/testdata/with_vars_plat/tmpl.yml
+++ b/template/native/testdata/with_vars_plat/tmpl.yml
@@ -1,0 +1,15 @@
+metadata:
+  template: true
+
+steps:
+  - name: test
+    commands:
+      - echo {{ vela "repo_full_name" }}
+      - echo {{ vela "REPO_FULL_NAME" }}
+      - echo {{ vela "vela_repo_full_name" }}
+      - echo {{ vela "VELA_REPO_FULL_NAME" }}
+      - echo {{ vela "non_existent" }}
+    image: alpine
+    pull: true
+    ruleset:
+      event: [ push, pull_request ]

--- a/template/native/testdata/with_vars_plat/want.yml
+++ b/template/native/testdata/with_vars_plat/want.yml
@@ -1,0 +1,12 @@
+steps:
+  - name: sample_test
+    commands:
+      - echo octocat/hello-world
+      - echo octocat/hello-world
+      - echo octocat/hello-world
+      - echo octocat/hello-world
+      - echo
+    image: alpine
+    pull: true
+    ruleset:
+      event: [ push, pull_request ]

--- a/template/starlark/render_test.go
+++ b/template/starlark/render_test.go
@@ -70,7 +70,7 @@ func TestStarlark_Render(t *testing.T) {
 				want := w.Steps
 
 				if diff := cmp.Diff(want, got); diff != "" {
-					t.Errorf("ExpandSteps() mismatch (-want +got):\n%s", diff)
+					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})


### PR DESCRIPTION
## changes

Updates Golang templates to automatically inject platform variables (`VELA_<VAR>`) utilizing the `vela` function.

## usage

Purpose the value of `VELA_FULL_REPO_NAME` is `foo/bar`, the following code would output `foo/bar` 4 times.

```
{{ vela "full_repo_name" }}
{{ vela "FULL_REPO_NAME" }}
{{ vela "VELA_FULL_REPO_NAME" }}
{{ vela "vela_full_repo_name" }}
```

closes https://github.com/go-vela/community/issues/72
closes https://github.com/go-vela/community/issues/113