### PR TITLE
refactor: set step directory from environment

### DIFF
--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -59,7 +59,7 @@ func (c *client) TransformStages(r *pipeline.RuleData, p *yaml.Build) (*pipeline
 			step.ID = pattern
 
 			// set the workspace directory
-			step.Directory = fmt.Sprintf("/vela/src/%s/%s/%s", c.metadata.Source.Host, org, name)
+			step.Directory = step.Environment["VELA_WORKSPACE"]
 		}
 	}
 
@@ -118,7 +118,7 @@ func (c *client) TransformSteps(r *pipeline.RuleData, p *yaml.Build) (*pipeline.
 		step.ID = pattern
 
 		// set the workspace directory
-		step.Directory = fmt.Sprintf("/vela/src/%s/%s/%s", c.metadata.Source.Host, org, name)
+		step.Directory = step.Environment["VELA_WORKSPACE"]
 	}
 
 	// set the unique ID for each service in the executable pipeline

--- a/compiler/native/transform_test.go
+++ b/compiler/native/transform_test.go
@@ -59,10 +59,11 @@ func TestNative_TransformStages(t *testing.T) {
 				Name: "install deps",
 				Steps: yaml.StepSlice{
 					&yaml.Step{
-						Commands: []string{"./gradlew downloadDependencies"},
-						Image:    "openjdk:latest",
-						Name:     "install",
-						Pull:     "always",
+						Commands:    []string{"./gradlew downloadDependencies"},
+						Environment: environment(nil, nil, nil, nil),
+						Image:       "openjdk:latest",
+						Name:        "install",
+						Pull:        "always",
 					},
 				},
 			},
@@ -71,10 +72,11 @@ func TestNative_TransformStages(t *testing.T) {
 				Needs: []string{"install"},
 				Steps: yaml.StepSlice{
 					&yaml.Step{
-						Commands: []string{"./gradlew check"},
-						Image:    "openjdk:latest",
-						Name:     "test",
-						Pull:     "always",
+						Commands:    []string{"./gradlew check"},
+						Environment: environment(nil, nil, nil, nil),
+						Image:       "openjdk:latest",
+						Name:        "test",
+						Pull:        "always",
 						Ruleset: yaml.Ruleset{
 							If: yaml.Rules{
 								Event: []string{"push"},
@@ -119,13 +121,14 @@ func TestNative_TransformStages(t *testing.T) {
 				Name: "install deps",
 				Steps: pipeline.ContainerSlice{
 					&pipeline.Container{
-						ID:        "__0_install deps_install",
-						Directory: "/vela/src/foo//",
-						Commands:  []string{"./gradlew downloadDependencies"},
-						Image:     "openjdk:latest",
-						Name:      "install",
-						Number:    1,
-						Pull:      "always",
+						ID:          "__0_install deps_install",
+						Commands:    []string{"./gradlew downloadDependencies"},
+						Directory:   "/vela",
+						Environment: environment(nil, nil, nil, nil),
+						Image:       "openjdk:latest",
+						Name:        "install",
+						Number:      1,
+						Pull:        "always",
 					},
 				},
 			},
@@ -214,16 +217,18 @@ func TestNative_TransformSteps(t *testing.T) {
 		},
 		Steps: yaml.StepSlice{
 			&yaml.Step{
-				Commands: []string{"./gradlew downloadDependencies"},
-				Image:    "openjdk:latest",
-				Name:     "install deps",
-				Pull:     "always",
+				Commands:    []string{"./gradlew downloadDependencies"},
+				Environment: environment(nil, nil, nil, nil),
+				Image:       "openjdk:latest",
+				Name:        "install deps",
+				Pull:        "always",
 			},
 			&yaml.Step{
-				Commands: []string{"./gradlew check"},
-				Image:    "openjdk:latest",
-				Name:     "test",
-				Pull:     "always",
+				Commands:    []string{"./gradlew check"},
+				Environment: environment(nil, nil, nil, nil),
+				Image:       "openjdk:latest",
+				Name:        "test",
+				Pull:        "always",
 				Ruleset: yaml.Ruleset{
 					If: yaml.Rules{
 						Event: []string{"push"},
@@ -263,13 +268,14 @@ func TestNative_TransformSteps(t *testing.T) {
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
-				ID:        "step___0_install deps",
-				Directory: "/vela/src/foo//",
-				Commands:  []string{"./gradlew downloadDependencies"},
-				Image:     "openjdk:latest",
-				Name:      "install deps",
-				Number:    1,
-				Pull:      "always",
+				ID:          "step___0_install deps",
+				Commands:    []string{"./gradlew downloadDependencies"},
+				Directory:   "/vela",
+				Environment: environment(nil, nil, nil, nil),
+				Image:       "openjdk:latest",
+				Name:        "install deps",
+				Number:      1,
+				Pull:        "always",
 			},
 		},
 		Secrets: pipeline.SecretSlice{


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This updates the compiler to set the `Directory` field for a step from the environment variable `VELA_WORKSPACE`.

Currently, we set a fallback default for the workspace:

https://github.com/go-vela/compiler/blob/4a43d157c9754b17e31a29dc35d4332949650a02/compiler/native/environment.go#L185

But then if the `go-vela/types.Metadata` field is set in the compiler, we use the standard workspace:

https://github.com/go-vela/compiler/blob/4a43d157c9754b17e31a29dc35d4332949650a02/compiler/native/environment.go#L217

Unfortunately, we end up duplicating this logic for `stages` and `steps` in the `Transform()` functions:

https://github.com/go-vela/compiler/blob/4a43d157c9754b17e31a29dc35d4332949650a02/compiler/native/transform.go#L61-L62

https://github.com/go-vela/compiler/blob/4a43d157c9754b17e31a29dc35d4332949650a02/compiler/native/transform.go#L120-L121

In a scenario where we compile a pipeline without that metadata type (CLI), this can cause a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2c567e9]

goroutine 27 [running]:
testing.tRunner.func1.1(0x2db7d80, 0x3cdd500)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1072 +0x46a
testing.tRunner.func1(0xc000416f00)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1075 +0x636
panic(0x2db7d80, 0x3cdd500)
	/usr/local/Cellar/go/1.15.6/libexec/src/runtime/panic.go:975 +0x47a
github.com/go-vela/compiler/compiler/native.(*client).TransformSteps(0xc00032e000, 0xc00001d870, 0xc0000f66e0, 0x4, 0xc000299d60, 0x3)
	.../go/pkg/mod/github.com/go-vela/compiler@v0.6.1/compiler/native/transform.go:121 +0x969
github.com/go-vela/compiler/compiler/native.(*client).Compile(0xc00032e000, 0x2d47c40, 0xc000423bc0, 0x15, 0xc000093a68, 0x1)
	.../go/pkg/mod/github.com/go-vela/compiler@v0.6.1/compiler/native/compile.go:178 +0x2631
github.com/go-vela/cli/action/pipeline.(*Config).Exec(0xc000093e38, 0x32558a0, 0xc00032e000, 0x0, 0x0)
	.../repos/github.com/go-vela/cli/action/pipeline/exec.go:47 +0x2cb
github.com/go-vela/cli/action/pipeline.TestPipeline_Config_Exec(0xc000416f00)
	.../repos/github.com/go-vela/cli/action/pipeline/exec_test.go:71 +0x5bd
testing.tRunner(0xc000416f00, 0x305d6a0)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1123 +0x203
created by testing.(*T).Run
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1168 +0x5bc
```