### PR TITLE
feat: skip clone process for local pipelines

### DIFF
--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -107,6 +107,9 @@ type Engine interface {
 	// WithFiles defines a function that sets
 	// the changeset files in the Engine.
 	WithFiles([]string) Engine
+	// WithLocal defines a function that sets
+	// the compiler local field in the Engine.
+	WithLocal(bool) Engine
 	// WithMetadata defines a function that sets
 	// the compiler Metadata type in the Engine.
 	WithMetadata(*types.Metadata) Engine

--- a/compiler/native/clone.go
+++ b/compiler/native/clone.go
@@ -20,6 +20,12 @@ const (
 
 // CloneStage injects the clone stage process into a yaml configuration.
 func (c *client) CloneStage(p *yaml.Build) (*yaml.Build, error) {
+	// check if the compiler is setup for a local pipeline
+	if c.local {
+		// skip injecting the clone process
+		return p, nil
+	}
+
 	stages := yaml.StageSlice{}
 
 	// create new clone stage
@@ -50,6 +56,12 @@ func (c *client) CloneStage(p *yaml.Build) (*yaml.Build, error) {
 
 // CloneStep injects the clone step process into a yaml configuration.
 func (c *client) CloneStep(p *yaml.Build) (*yaml.Build, error) {
+	// check if the compiler is setup for a local pipeline
+	if c.local {
+		// skip injecting the clone process
+		return p, nil
+	}
+
 	steps := yaml.StepSlice{}
 
 	// create new clone step

--- a/compiler/native/clone_test.go
+++ b/compiler/native/clone_test.go
@@ -35,45 +35,78 @@ func TestNative_CloneStage(t *testing.T) {
 		},
 	}
 
-	want := &yaml.Build{
-		Version: "v1",
-		Stages: yaml.StageSlice{
-			&yaml.Stage{
-				Name: "clone",
-				Steps: yaml.StepSlice{
-					&yaml.Step{
-						Image: "target/vela-git:v0.4.0",
-						Name:  "clone",
-						Pull:  "not_present",
+	// setup tests
+	tests := []struct {
+		failure  bool
+		local    bool
+		pipeline *yaml.Build
+		want     *yaml.Build
+	}{
+		{
+			failure:  false,
+			local:    false,
+			pipeline: p,
+			want: &yaml.Build{
+				Version: "v1",
+				Stages: yaml.StageSlice{
+					&yaml.Stage{
+						Name: "clone",
+						Steps: yaml.StepSlice{
+							&yaml.Step{
+								Image: "target/vela-git:v0.4.0",
+								Name:  "clone",
+								Pull:  "not_present",
+							},
+						},
 					},
-				},
-			},
-			&yaml.Stage{
-				Name: str,
-				Steps: yaml.StepSlice{
-					&yaml.Step{
-						Image: "alpine",
-						Name:  str,
-						Pull:  "not_present",
+					&yaml.Stage{
+						Name: str,
+						Steps: yaml.StepSlice{
+							&yaml.Step{
+								Image: "alpine",
+								Name:  str,
+								Pull:  "not_present",
+							},
+						},
 					},
 				},
 			},
 		},
+		{
+			failure:  false,
+			local:    true,
+			pipeline: p,
+			want:     p,
+		},
 	}
 
-	// run test
-	compiler, err := New(c)
-	if err != nil {
-		t.Errorf("Unable to create new compiler: %v", err)
-	}
+	// run tests
+	for _, test := range tests {
+		compiler, err := New(c)
+		if err != nil {
+			t.Errorf("Unable to create new compiler: %v", err)
+		}
 
-	got, err := compiler.CloneStage(p)
-	if err != nil {
-		t.Errorf("CloneStage returned err: %v", err)
-	}
+		// set the local field for the test
+		compiler.WithLocal(test.local)
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("CloneStage is %v, want %v", got, want)
+		got, err := compiler.CloneStage(test.pipeline)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CloneStage should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CloneStage returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("CloneStage is %v, want %v", got, test.want)
+		}
 	}
 }
 
@@ -94,33 +127,67 @@ func TestNative_CloneStep(t *testing.T) {
 		},
 	}
 
-	want := &yaml.Build{
-		Version: "v1",
-		Steps: yaml.StepSlice{
-			&yaml.Step{
-				Image: "target/vela-git:v0.4.0",
-				Name:  "clone",
-				Pull:  "not_present",
-			},
-			&yaml.Step{
-				Image: "alpine",
-				Name:  str,
-				Pull:  "not_present",
+	// setup tests
+	tests := []struct {
+		failure  bool
+		local    bool
+		pipeline *yaml.Build
+		want     *yaml.Build
+	}{
+		{
+			failure:  false,
+			local:    false,
+			pipeline: p,
+			want: &yaml.Build{
+				Version: "v1",
+				Steps: yaml.StepSlice{
+					&yaml.Step{
+						Image: "target/vela-git:v0.4.0",
+						Name:  "clone",
+						Pull:  "not_present",
+					},
+					&yaml.Step{
+						Image: "alpine",
+						Name:  str,
+						Pull:  "not_present",
+					},
+				},
 			},
 		},
-	}
-	// run test
-	compiler, err := New(c)
-	if err != nil {
-		t.Errorf("Unable to create new compiler: %v", err)
-	}
-
-	got, err := compiler.CloneStep(p)
-	if err != nil {
-		t.Errorf("CloneStep returned err: %v", err)
+		{
+			failure:  false,
+			local:    true,
+			pipeline: p,
+			want:     p,
+		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("CloneStep is %v, want %v", got, want)
+	// run tests
+	for _, test := range tests {
+		compiler, err := New(c)
+		if err != nil {
+			t.Errorf("Unable to create new compiler: %v", err)
+		}
+
+		// set the local field for the test
+		compiler.WithLocal(test.local)
+
+		got, err := compiler.CloneStep(test.pipeline)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CloneStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CloneStep returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("CloneStep is %v, want %v", got, test.want)
+		}
 	}
 }

--- a/compiler/native/clone_test.go
+++ b/compiler/native/clone_test.go
@@ -84,7 +84,7 @@ func TestNative_CloneStage(t *testing.T) {
 	for _, test := range tests {
 		compiler, err := New(c)
 		if err != nil {
-			t.Errorf("Unable to create new compiler: %v", err)
+			t.Errorf("unable to create new compiler: %v", err)
 		}
 
 		// set the local field for the test

--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -34,6 +34,7 @@ type client struct {
 	build    *library.Build
 	comment  string
 	files    []string
+	local    bool
 	metadata *types.Metadata
 	repo     *library.Repo
 	user     *library.User
@@ -42,7 +43,7 @@ type client struct {
 // New returns a Pipeline implementation that integrates with the supported registries.
 func New(ctx *cli.Context) (*client, error) {
 	logrus.Debug("Creating registry clients from CLI configuration")
-	c := client{}
+	c := new(client)
 
 	if ctx.String("modification-addr") != "" {
 		c.ModificationService = ModificationConfig{
@@ -71,7 +72,7 @@ func New(ctx *cli.Context) (*client, error) {
 		c.PrivateGithub = privGithub
 	}
 
-	return &c, nil
+	return c, nil
 }
 
 // setupGithub is a helper function to setup the
@@ -111,6 +112,13 @@ func (c *client) WithFiles(f []string) compiler.Engine {
 	if f != nil {
 		c.files = f
 	}
+
+	return c
+}
+
+// WithLocal sets the compiler metadata type in the Engine.
+func (c *client) WithLocal(local bool) compiler.Engine {
+	c.local = local
 
 	return c
 }

--- a/compiler/native/native_test.go
+++ b/compiler/native/native_test.go
@@ -129,6 +129,26 @@ func TestNative_WithComment(t *testing.T) {
 	}
 }
 
+func TestNative_WithLocal(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	c := cli.NewContext(nil, set, nil)
+
+	local := true
+	want, _ := New(c)
+	want.local = true
+
+	// run test
+	got, err := New(c)
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	if !reflect.DeepEqual(got.WithLocal(local), want) {
+		t.Errorf("WithLocal is %v, want %v", got, want)
+	}
+}
+
 func TestNative_WithMetadata(t *testing.T) {
 	// setup types
 	set := flag.NewFlagSet("test", 0)

--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -38,6 +38,16 @@ func (c *client) TransformStages(r *pipeline.RuleData, p *yaml.Build) (*pipeline
 	name := c.repo.GetName()
 	number := c.build.GetNumber()
 
+	// check if the compiler is setup for a local pipeline
+	if c.local {
+		// set a default for the org
+		org = "localOrg"
+		// set a default for the repo
+		name = "localRepo"
+		// set a default for the number
+		number = 1
+	}
+
 	// create new executable pipeline
 	pipeline := &pipeline.Build{
 		Version:  p.Version,
@@ -97,6 +107,16 @@ func (c *client) TransformSteps(r *pipeline.RuleData, p *yaml.Build) (*pipeline.
 	org := c.repo.GetOrg()
 	name := c.repo.GetName()
 	number := c.build.GetNumber()
+
+	// check if the compiler is setup for a local pipeline
+	if c.local {
+		// set a default for the org
+		org = "localOrg"
+		// set a default for the repo
+		name = "localRepo"
+		// set a default for the number
+		number = 1
+	}
 
 	// create new executable pipeline
 	pipeline := &pipeline.Build{


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

NOTE: The LOC changed in this PR is a bit misleading due to the tests.

## Part 1

Adding a `local` field to the compiler:

https://github.com/go-vela/compiler/blob/3c8cfcb9de429678d357704f850f3a79bf5f6998/compiler/native/native.go#L37

And allowing that field to be set via the `WithLocal()` function:

https://github.com/go-vela/compiler/blob/3c8cfcb9de429678d357704f850f3a79bf5f6998/compiler/native/native.go#L119-L124

## Part 2

Updating the compiler to skip injecting the clone process if the `local` field is set:

https://github.com/go-vela/compiler/blob/3c8cfcb9de429678d357704f850f3a79bf5f6998/compiler/native/clone.go#L21-L27

https://github.com/go-vela/compiler/blob/3c8cfcb9de429678d357704f850f3a79bf5f6998/compiler/native/clone.go#L57-L63

## Part 3

Updating the compiler to set "defaults" for the repo org and name as well as the build number:

https://github.com/go-vela/compiler/blob/3c8cfcb9de429678d357704f850f3a79bf5f6998/compiler/native/transform.go#L34-L49

https://github.com/go-vela/compiler/blob/3c8cfcb9de429678d357704f850f3a79bf5f6998/compiler/native/transform.go#L104-L119