### PR TITLE
refactor: allow overrides of local variables

### DIFF
--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	// default org for pipeline
+	// default org for pipeline.
 	localOrg = "localOrg"
-	// default repo for pipeline
+	// default repo for pipeline.
 	localRepo = "localRepo"
-	// default build number for pipeline
+	// default build number for pipeline.
 	localBuild = 1
 	// default ID for pipeline.
 	// format: `<org>_<repo>_<build number>`

--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -12,6 +12,12 @@ import (
 )
 
 const (
+	// default org for pipeline
+	localOrg = "localOrg"
+	// default repo for pipeline
+	localRepo = "localRepo"
+	// default build number for pipeline
+	localBuild = 0
 	// default ID for pipeline.
 	// format: `<org>_<repo>_<build number>`
 	pipelineID = "%s_%s_%d"
@@ -41,11 +47,11 @@ func (c *client) TransformStages(r *pipeline.RuleData, p *yaml.Build) (*pipeline
 	// check if the compiler is setup for a local pipeline
 	if c.local {
 		// set a default for the org
-		org = "localOrg"
+		org = localOrg
 		// set a default for the repo
-		name = "localRepo"
+		name = localRepo
 		// set a default for the number
-		number = 1
+		number = localBuild
 	}
 
 	// create new executable pipeline
@@ -111,11 +117,11 @@ func (c *client) TransformSteps(r *pipeline.RuleData, p *yaml.Build) (*pipeline.
 	// check if the compiler is setup for a local pipeline
 	if c.local {
 		// set a default for the org
-		org = "localOrg"
+		org = localOrg
 		// set a default for the repo
-		name = "localRepo"
+		name = localRepo
 		// set a default for the number
-		number = 1
+		number = localBuild
 	}
 
 	// create new executable pipeline

--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -17,7 +17,7 @@ const (
 	// default repo for pipeline
 	localRepo = "localRepo"
 	// default build number for pipeline
-	localBuild = 0
+	localBuild = 1
 	// default ID for pipeline.
 	// format: `<org>_<repo>_<build number>`
 	pipelineID = "%s_%s_%d"

--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -46,12 +46,23 @@ func (c *client) TransformStages(r *pipeline.RuleData, p *yaml.Build) (*pipeline
 
 	// check if the compiler is setup for a local pipeline
 	if c.local {
-		// set a default for the org
-		org = localOrg
-		// set a default for the repo
-		name = localRepo
-		// set a default for the number
-		number = localBuild
+		// check if the org provided is empty
+		if len(org) == 0 {
+			// set a default for the org
+			org = localOrg
+		}
+
+		// check if the repo provided is empty
+		if len(name) == 0 {
+			// set a default for the repo
+			name = localRepo
+		}
+
+		// check if the number provided is empty
+		if number == 0 {
+			// set a default for the number
+			number = localBuild
+		}
 	}
 
 	// create new executable pipeline
@@ -116,12 +127,23 @@ func (c *client) TransformSteps(r *pipeline.RuleData, p *yaml.Build) (*pipeline.
 
 	// check if the compiler is setup for a local pipeline
 	if c.local {
-		// set a default for the org
-		org = localOrg
-		// set a default for the repo
-		name = localRepo
-		// set a default for the number
-		number = localBuild
+		// check if the org provided is empty
+		if len(org) == 0 {
+			// set a default for the org
+			org = localOrg
+		}
+
+		// check if the repo provided is empty
+		if len(name) == 0 {
+			// set a default for the repo
+			name = localRepo
+		}
+
+		// check if the number provided is empty
+		if number == 0 {
+			// set a default for the number
+			number = localBuild
+		}
 	}
 
 	// create new executable pipeline


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

A continuation of https://github.com/go-vela/compiler/pull/110

## Part 1

Setting constants for the `local` defaults we create:

https://github.com/go-vela/compiler/blob/a33f2cbfc8b88bdaae7f875a9afe025ed70235bf/compiler/native/transform.go#L15-L20

## Part 2

Allowing the `local` defaults to be overridden if a valid build and repo are provided 👍 

https://github.com/go-vela/compiler/blob/a33f2cbfc8b88bdaae7f875a9afe025ed70235bf/compiler/native/transform.go#L47-L66