### PR TITLE
feat: set os env vars for local compiler

### DIFF
--- a/compiler/native/environment.go
+++ b/compiler/native/environment.go
@@ -6,6 +6,7 @@ package native
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/go-vela/types"
@@ -53,6 +54,17 @@ func (c *client) EnvironmentStep(s *yaml.Step) (*yaml.Step, error) {
 	// gather set of default environment variables
 	defaultEnv := environment(c.build, c.metadata, c.repo, c.user)
 
+	// check if the compiler is setup for a local pipeline
+	if c.local {
+		// capture all environment variables from the local environment
+		for _, e := range os.Environ() {
+			// split the environment variable on = into a key value pair
+			parts := strings.SplitN(e, "=", 2)
+
+			env[parts[0]] = parts[1]
+		}
+	}
+
 	// inject the declared environment
 	// variables to the build step
 	for k, v := range s.Environment {
@@ -99,6 +111,17 @@ func (c *client) EnvironmentServices(s yaml.ServiceSlice) (yaml.ServiceSlice, er
 		// gather set of default environment variables
 		defaultEnv := environment(c.build, c.metadata, c.repo, c.user)
 
+		// check if the compiler is setup for a local pipeline
+		if c.local {
+			// capture all environment variables from the local environment
+			for _, e := range os.Environ() {
+				// split the environment variable on = into a key value pair
+				parts := strings.SplitN(e, "=", 2)
+
+				env[parts[0]] = parts[1]
+			}
+		}
+
 		// inject the declared environment
 		// variables to the build service
 		for k, v := range service.Environment {
@@ -134,6 +157,17 @@ func (c *client) EnvironmentSecrets(s yaml.SecretSlice) (yaml.SecretSlice, error
 		env := make(map[string]string)
 		// gather set of default environment variables
 		defaultEnv := environment(c.build, c.metadata, c.repo, c.user)
+
+		// check if the compiler is setup for a local pipeline
+		if c.local {
+			// capture all environment variables from the local environment
+			for _, e := range os.Environ() {
+				// split the environment variable on = into a key value pair
+				parts := strings.SplitN(e, "=", 2)
+
+				env[parts[0]] = parts[1]
+			}
+		}
 
 		// inject the declared environment
 		// variables to the build secret


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

I was playing around with the CLI locally trying to run pipelines on my workstation.

I noticed that if I set an environment variable in my terminal, and then attempted to use it in the pipeline, it was empty.

Here is the way I set the environment variable in my terminal:

```sh
export TEST_VELA=foo
```

Here is the pipeline I was using:

```yaml
version: "1"

steps:
  - name: sample
    image: alpine:latest
    commands:
      - echo $TEST_VELA
      - echo ${TEST_VELA}
```

Before this PR, the output looks like this:

```sh
[step: sample] $ echo $TEST_VELA
[step: sample]
[step: sample] $ echo
[step: sample]
```

Now, the output looks like this:

```sh
[step: sample] $ echo $TEST_VELA
[step: sample] foo
[step: sample] $ echo foo
[step: sample] foo
```