### PR TITLE
fix(modification): send as yaml string since json fails

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -21,14 +21,16 @@ import (
 	"github.com/go-vela/types/yaml"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
+
+	uyaml "github.com/goccy/go-yaml"
 )
 
 // ModifyRequest contains the payload passed to the modification endpoint
 type ModifyRequest struct {
-	Pipeline *yaml.Build `json:"pipeline,omitempty"`
-	Build    int         `json:"build,omitempty"`
-	Repo     string      `json:"repo,omitempty"`
-	User     string      `json:"user,omitempty"`
+	Pipeline string `json:"pipeline,omitempty"`
+	Build    int    `json:"build,omitempty"`
+	Repo     string `json:"repo,omitempty"`
+	User     string `json:"user,omitempty"`
 }
 
 // Compile produces an executable pipeline from a yaml configuration.
@@ -210,8 +212,13 @@ func errorHandler(resp *http.Response, err error, attempts int) (*http.Response,
 // nolint:lll // parameter struct references push line limit
 func (c *client) modifyConfig(build *yaml.Build, libraryBuild *library.Build, repo *library.Repo) (*yaml.Build, error) {
 	// create request to send to endpoint
+	data, err := uyaml.Marshal(build)
+	if err != nil {
+		return nil, err
+	}
+
 	modReq := &ModifyRequest{
-		Pipeline: build,
+		Pipeline: string(data),
 		Build:    libraryBuild.GetNumber(),
 		Repo:     repo.GetName(),
 		User:     libraryBuild.GetAuthor(),

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -1403,6 +1403,11 @@ func Test_client_modifyConfig(t *testing.T) {
 				Environment: nil,
 				Name:        "docker",
 				Pull:        "always",
+				Parameters: map[string]interface{}{
+					"init_options": map[string]interface{}{
+						"get_plugins": "true",
+					},
+				},
 			},
 		},
 	}
@@ -1430,6 +1435,11 @@ func Test_client_modifyConfig(t *testing.T) {
 				Environment: nil,
 				Name:        "docker",
 				Pull:        "always",
+				Parameters: map[string]interface{}{
+					"init_options": map[string]interface{}{
+						"get_plugins": "true",
+					},
+				},
 			},
 			&yaml.Step{
 				Image:       "alpine",
@@ -1548,8 +1558,8 @@ func Test_client_modifyConfig(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("modifyConfig() got = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("modifyConfig() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
The existing code will fail with the error of `json: unsupported type: map[interface {}]interface {}` with configurations like:

```yaml
version: "1"
steps:
  - name: test
    image: foo
    parameters:
      init_options:
        get_plugins: true
```

This is occurring since maps with keys that are maps is not supported by JSON. Administrators that are currently utilizing the modification service will need to update the receiving API to unmarshal like the following:

```go
import (
  "github.com/go-vela/compiler/compiler/native"
  "github.com/go-vela/types/yaml"

   uyaml "github.com/goccy/go-yaml"
)

var payload native.ModifyRequest
// ensure the payload matches the expected struct
if err := c.ShouldBindJSON(&payload); err != nil {
  c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
  return
}

var pipeline yaml.Build
err := uyaml.Unmarshal([]byte(payload.Pipeline), &pipeline)
if err != nil {
  c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
  return
}
```