### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,7 +58,23 @@ cd $HOME/go-vela/compiler
 ```
 
 * Write your code
-  - Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
+
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
 
 * Write tests for your changes and ensure they pass:
 
@@ -83,4 +99,25 @@ go vet ./...
 git push fork master
 ```
 
-* Open a pull request. Thank you for your contribution!
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -131,6 +131,7 @@ issues:
     # prevent linters from running on *_test.go files
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - goconst
         - gocyclo

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -21,11 +21,9 @@ import (
 	"github.com/go-vela/types/yaml"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
-
-	uyaml "github.com/goccy/go-yaml"
 )
 
-// ModifyRequest contains the payload passed to the modification endpoint
+// ModifyRequest contains the payload passed to the modification endpoint.
 type ModifyRequest struct {
 	Pipeline string `json:"pipeline,omitempty"`
 	Build    int    `json:"build,omitempty"`
@@ -34,6 +32,8 @@ type ModifyRequest struct {
 }
 
 // Compile produces an executable pipeline from a yaml configuration.
+//
+// nolint: funlen // ignore function length due to comments
 func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 	// parse the object into a yaml configuration
 	p, raw, err := c.Parse(v)
@@ -212,7 +212,7 @@ func errorHandler(resp *http.Response, err error, attempts int) (*http.Response,
 // nolint:lll // parameter struct references push line limit
 func (c *client) modifyConfig(build *yaml.Build, libraryBuild *library.Build, repo *library.Repo) (*yaml.Build, error) {
 	// create request to send to endpoint
-	data, err := uyaml.Marshal(build)
+	data, err := yml.Marshal(build)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -17,6 +17,8 @@ import (
 
 // ExpandStages injects the template for each
 // templated step in every stage in a yaml configuration.
+//
+// nolint: lll // ignore long line length due to variable names
 func (c *client) ExpandStages(s yaml.StageSlice, tmpls map[string]*yaml.Template) (yaml.StageSlice, error) {
 	// iterate through all stages
 	for _, stage := range s {
@@ -34,6 +36,8 @@ func (c *client) ExpandStages(s yaml.StageSlice, tmpls map[string]*yaml.Template
 
 // ExpandSteps injects the template for each
 // templated step in a yaml configuration.
+//
+// nolint: lll // ignore long line length due to variable names
 func (c *client) ExpandSteps(s yaml.StepSlice, tmpls map[string]*yaml.Template) (yaml.StepSlice, error) {
 	steps := yaml.StepSlice{}
 

--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -41,6 +41,8 @@ type client struct {
 }
 
 // New returns a Pipeline implementation that integrates with the supported registries.
+//
+// nolint: golint // ignore returning unexported client
 func New(ctx *cli.Context) (*client, error) {
 	logrus.Debug("Creating registry clients from CLI configuration")
 	c := new(client)

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -797,5 +797,5 @@ func TestNative_ParseString_Metadata(t *testing.T) {
 type FailReader struct{}
 
 func (FailReader) Read(p []byte) (n int, err error) {
-	return 0, errors.New("This is a reader that fails when you try to read.")
+	return 0, errors.New("this is a reader that fails when you try to read")
 }

--- a/compiler/native/script.go
+++ b/compiler/native/script.go
@@ -49,7 +49,9 @@ func (c *client) ScriptSteps(s yaml.StepSlice) (yaml.StepSlice, error) {
 
 		// set the environment variables for the step
 		step.Environment["VELA_BUILD_SCRIPT"] = script
+		// nolint: goconst // ignore making this a constant for now
 		step.Environment["HOME"] = "/root"
+		// nolint: goconst // ignore making this a constant for now
 		step.Environment["SHELL"] = "/bin/sh"
 	}
 
@@ -57,7 +59,7 @@ func (c *client) ScriptSteps(s yaml.StepSlice) (yaml.StepSlice, error) {
 }
 
 // generateScriptPosix is a helper function that generates a build script
-// for a linux container using the given commands
+// for a linux container using the given commands.
 func generateScriptPosix(commands []string) string {
 	var buf bytes.Buffer
 

--- a/registry/github/github.go
+++ b/registry/github/github.go
@@ -25,6 +25,8 @@ type client struct {
 
 // New returns a Registry implementation that integrates
 // with GitHub or a GitHub Enterprise instance.
+//
+// nolint: golint // ignore returning unexported client
 func New(address, token string) (*client, error) {
 	// create the client object
 	c := &client{

--- a/registry/github/template.go
+++ b/registry/github/template.go
@@ -31,6 +31,8 @@ func (c *client) Template(u *library.User, s *registry.Source) ([]byte, error) {
 	}
 
 	// send API call to capture the templated pipeline configuration
+	//
+	// nolint: lll // ignore long line length due to variable names
 	data, _, resp, err := cli.Repositories.GetContents(context.Background(), s.Org, s.Repo, s.Name, opts)
 	if err != nil {
 		if resp.StatusCode != http.StatusNotFound {
@@ -48,5 +50,5 @@ func (c *client) Template(u *library.User, s *registry.Source) ([]byte, error) {
 		return []byte(strData), nil
 	}
 
-	return nil, fmt.Errorf("No valid template found at %s/%s/%s", s.Org, s.Repo, s.Name)
+	return nil, fmt.Errorf("no valid template found at %s/%s/%s", s.Org, s.Repo, s.Name)
 }

--- a/template/starlark/convert_test.go
+++ b/template/starlark/convert_test.go
@@ -60,7 +60,6 @@ func TestStarlark_Render_convertTemplateVars(t *testing.T) {
 		},
 		{
 			name: "test for a user passed map",
-			// nolint // ignore line length
 			args: map[string]interface{}{"commands": map[string]string{"test": "go test ./..."}},
 			want: mapWant,
 		}}

--- a/template/starlark/render.go
+++ b/template/starlark/render.go
@@ -29,7 +29,8 @@ var (
 )
 
 // Render combines the template with the step in the yaml pipeline.
-// nolint // ignore function line length
+//
+// nolint: funlen // ignore function length due to comments
 func Render(tmpl string, s *types.Step) (types.StepSlice, error) {
 	config := new(types.Build)
 
@@ -37,6 +38,8 @@ func Render(tmpl string, s *types.Step) (types.StepSlice, error) {
 	// arbitrarily limiting the steps of the thread to 5000 to help prevent infinite loops
 	// may need to further investigate spawning a separate POSIX process if user input is problematic
 	// see https://github.com/google/starlark-go/issues/160#issuecomment-466794230 for further details
+	//
+	// nolint: gomnd // ignore magic number
 	thread.SetMaxExecutionSteps(5000)
 	globals, err := starlark.ExecFile(thread, s.Template.Name, tmpl, nil)
 	if err != nil {

--- a/template/starlark/starlark.go
+++ b/template/starlark/starlark.go
@@ -30,8 +30,10 @@ var (
 // will return the comparable Starlark type.
 //
 // This code is under copyright (full attribution in NOTICE) and is from:
+//
 // https://github.com/wonderix/shalm/blob/899b8f7787883d40619eefcc39bd12f42a09b5e7/pkg/shalm/convert.go#L14-L85
-// nolint /// @lll ignore line length of the link
+//
+// nolint: gocyclo,funlen,lll // ignore above line length and function length due to comments
 func toStarlark(value interface{}) (starlark.Value, error) {
 	logrus.Tracef("converting %v to starlark type", value)
 
@@ -88,6 +90,7 @@ func toStarlark(value interface{}) (starlark.Value, error) {
 
 		return val, nil
 	case reflect.Map:
+		// nolint: gomnd // ignore magic number
 		d := starlark.NewDict(16)
 
 		for _, key := range v.MapKeys() {
@@ -141,12 +144,14 @@ func toStarlark(value interface{}) (starlark.Value, error) {
 // for the specific type.
 //
 // This code is under copyright (full attribution in NOTICE) and is from:
+//
 // https://github.com/drone/drone-cli/blob/master/drone/starlark/starlark.go#L214-L274
 //
 // Note: we are using logrus log unchecked errors that the original implementation ignored.
 // if/when we try to return values it breaks the recursion. Panics were swapped to error
 // returns from implementation.
-// nolint // ignore function line length
+//
+// nolint: gocyclo,funlen // ignore cyclomatic complexity and function length
 func writeJSON(out *bytes.Buffer, v starlark.Value) error {
 	logrus.Tracef("converting %v to JSON", v)
 


### PR DESCRIPTION
Continuation of the efforts from https://github.com/go-vela/mock/pull/76 and https://github.com/go-vela/types/pull/122

* Updating the contributing guide to include fixing linter warnings if any are present
* Skipping the `dupl` and `lll` linters on `*_test.go` files
* Added `nolint` directives across the repo to address any current linter issues