### PR TITLE
fix: missing validate on interface from revert

### DIFF
--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -29,6 +29,10 @@ type Engine interface {
 	// an object to a yaml configuration.
 	Parse(interface{}) (*yaml.Build, error)
 
+	// Validate defines a function that verifies
+	// the yaml configuration is accurate.
+	Validate(*yaml.Build) error
+
 	// Clone Compiler Interface Functions
 
 	// CloneStage defines a function that injects the


### PR DESCRIPTION
This change was missed when we rolled back the goccy change. 

We need a public validate function on the interface for the pipeline API funcs:

https://github.com/go-vela/server/blob/master/api/pipeline.go#L446