### PR TITLE
fix(modification): return json with yaml string to avoid invalid JSON

### DIFF
--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -1348,7 +1348,7 @@ func TestNative_Compile_StepsandStages(t *testing.T) {
 	}
 }
 
-// convertResponse converts the build to the ModifyResponse
+// convertResponse converts the build to the ModifyResponse.
 func convertResponse(build *yaml.Build) (*ModifyResponse, error) {
 	data, err := yml.Marshal(build)
 	if err != nil {

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -1472,6 +1472,7 @@ func Test_client_modifyConfig(t *testing.T) {
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
 		c.JSON(http.StatusOK, response)
 	})
@@ -1482,6 +1483,7 @@ func Test_client_modifyConfig(t *testing.T) {
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
 		c.JSON(http.StatusOK, response)
 	})
@@ -1502,8 +1504,8 @@ func Test_client_modifyConfig(t *testing.T) {
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
-
 		c.JSON(http.StatusOK, response)
 	})
 
@@ -1516,6 +1518,7 @@ func Test_client_modifyConfig(t *testing.T) {
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
 		c.JSON(http.StatusForbidden, response)
 	})

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/drone/envsubst v1.0.2
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/types v0.7.1-0.20210204153653-939416ae12ed
-	github.com/goccy/go-yaml v1.8.8
+	github.com/goccy/go-yaml v1.8.8 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/go-cmp v0.5.4


### PR DESCRIPTION
Modifying the existing code to expect the modification API to return responses like:

```json
{
  "pipeline": "<pipeline in yaml format>"
}
```

Continuing the fixes from https://github.com/go-vela/compiler/pull/127.
