### PR TITLE
fix(secrets/services): populate environment within stages before plan

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -66,6 +66,12 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 		Target:  c.build.GetDeploy(),
 	}
 
+	// inject the environment variables into the services
+	p.Services, err = c.EnvironmentServices(p.Services)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(p.Stages) > 0 {
 		// check if the pipeline disabled the clone
 		if p.Metadata.Clone == nil || *p.Metadata.Clone {

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -66,18 +66,6 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 		Target:  c.build.GetDeploy(),
 	}
 
-	// inject the environment variables into the services
-	p.Services, err = c.EnvironmentServices(p.Services)
-	if err != nil {
-		return nil, err
-	}
-
-	// inject the environment variables into the secrets
-	p.Secrets, err = c.EnvironmentSecrets(p.Secrets)
-	if err != nil {
-		return nil, err
-	}
-
 	if len(p.Stages) > 0 {
 		// check if the pipeline disabled the clone
 		if p.Metadata.Clone == nil || *p.Metadata.Clone {
@@ -110,6 +98,18 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 
 		// validate the yaml configuration
 		err = c.Validate(p)
+		if err != nil {
+			return nil, err
+		}
+
+		// inject the environment variables into the services
+		p.Services, err = c.EnvironmentServices(p.Services)
+		if err != nil {
+			return nil, err
+		}
+
+		// inject the environment variables into the secrets
+		p.Secrets, err = c.EnvironmentSecrets(p.Secrets)
 		if err != nil {
 			return nil, err
 		}

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -72,6 +72,12 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
 		return nil, err
 	}
 
+	// inject the environment variables into the secrets
+	p.Secrets, err = c.EnvironmentSecrets(p.Secrets)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(p.Stages) > 0 {
 		// check if the pipeline disabled the clone
 		if p.Metadata.Clone == nil || *p.Metadata.Clone {

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -744,12 +744,13 @@ func TestNative_Compile_StagesPipelineTemplate(t *testing.T) {
 		},
 		Services: pipeline.ContainerSlice{
 			&pipeline.Container{
-				ID:     "service___0_postgres",
-				Detach: true,
-				Image:  "postgres:12",
-				Name:   "postgres",
-				Number: 1,
-				Pull:   "not_present",
+				ID:          "service___0_postgres",
+				Detach:      true,
+				Image:       "postgres:12",
+				Name:        "postgres",
+				Number:      1,
+				Pull:        "not_present",
+				Environment: environment(nil, m, nil, nil),
 			},
 		},
 	}


### PR DESCRIPTION
We need to properly inject the environment for secrets and services when they are used within stages. This issue was realized once we saw the following stack trace:

```
assignment to entry in nil map
/usr/local/Cellar/go/1.16.3/libexec/src/runtime/map_faststr.go:204 (0x41478c)
/Users/user/go/pkg/mod/github.com/go-vela/types@v0.8.0-rc1/pipeline/container.go:240 (0x98a2b6)
/Users/user/repos/github.com/go-vela/server/api/service.go:538 (0x12ed972)
/Users/user/repos/github.com/go-vela/server/api/build.go:1023 (0x12ce744)
/Users/user/repos/github.com/go-vela/server/api/webhook.go:435 (0x12f812c)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12fda36)
/Users/user/repos/github.com/go-vela/server/router/middleware/header.go:32 (0x12fda1d)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12fd939)
/Users/user/repos/github.com/go-vela/server/router/middleware/header.go:22 (0x12fd91c)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x1300124)
/Users/user/repos/github.com/go-vela/server/router/middleware/worker.go:18 (0x1300107)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12ffe82)
/Users/user/repos/github.com/go-vela/server/router/middleware/secure_cookie.go:16 (0x12ffe65)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x1300042)
/Users/user/repos/github.com/go-vela/server/router/middleware/webhook_validation.go:16 (0x1300025)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12feac4)
/Users/user/repos/github.com/go-vela/server/router/middleware/default_timeout.go:16 (0x12feaa7)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12fe81b)
/Users/user/repos/github.com/go-vela/server/router/middleware/allowlist.go:16 (0x12fe7fe)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12fff62)
/Users/user/repos/github.com/go-vela/server/router/middleware/source.go:17 (0x12fff45)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12ffdb1)
/Users/user/repos/github.com/go-vela/server/router/middleware/secret.go:29 (0x12ffd90)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12ffc6e)
/Users/user/repos/github.com/go-vela/server/router/middleware/secret.go:18 (0x12ffc50)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12ffb82)
/Users/user/repos/github.com/go-vela/server/router/middleware/queue.go:17 (0x12ffb65)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12ff8b6)
/Users/user/repos/github.com/go-vela/server/router/middleware/metadata.go:18 (0x12ff899)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12febe8)
/Users/user/repos/github.com/go-vela/server/router/middleware/logger.go:32 (0x12febaa)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12fe9e2)
/Users/user/repos/github.com/go-vela/server/router/middleware/database.go:17 (0x12fe9c5)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x12fe902)
/Users/user/repos/github.com/go-vela/server/router/middleware/compiler.go:17 (0x12fe8e5)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x97e939)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 (0x97e920)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x974c89)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 (0x974c6f)
/Users/user/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 (0x97475b)
/usr/local/Cellar/go/1.16.3/libexec/src/net/http/server.go:2887 (0x6f27a2)
/usr/local/Cellar/go/1.16.3/libexec/src/net/http/server.go:1952 (0x6edbcc)
/usr/local/Cellar/go/1.16.3/libexec/src/runtime/asm_amd64.s:1371 (0x46d1c0)
```

The yaml file that produced the stack trace looked like:

```yaml
version: "1"
services:
  - name: mongo
    image: mongo:latest
stages:
  redis:
    steps:
      - name: redis
        image: redis:latest
        detach: true
      - name: check status
        image: redis:latest
        commands:
          - sleep 15
          - redis-cli -h redis ping
  mongo:
    steps:
      - name: check status
        image: mongo:latest
        commands:
          - sleep 15
          - "mongo --host mongo --eval \"{ ping: 1 }\""
```