### PR TITLE
chore: upgrade go-vela/types on v0.8.0-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/drone/envsubst v1.0.2
 	github.com/gin-gonic/gin v1.7.2
-	github.com/go-vela/types v0.8.0-rc1
+	github.com/go-vela/types v0.8.0-rc2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v35 v35.2.0
 	github.com/google/uuid v1.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/go-vela/types v0.8.0-rc1 h1:jRlrjCKxYuTvqE4StER9Y3sAMqaU5yJoPcl0zM3bLL8=
-github.com/go-vela/types v0.8.0-rc1/go.mod h1:tKk+FpEAv+BTMr9CL3Wed6tMy5IqyOCJpRTKZI88yDc=
+github.com/go-vela/types v0.8.0-rc2 h1:O9YYfdCCuHxPZ9aaXwcp/LNDLnAaHMMqfLkj4LaR69U=
+github.com/go-vela/types v0.8.0-rc2/go.mod h1:tKk+FpEAv+BTMr9CL3Wed6tMy5IqyOCJpRTKZI88yDc=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=


### PR DESCRIPTION
This updates `github.com/go-vela/types` to `v0.8.0-rc2`