### PR TITLE
enhance(vars): inject template name

### DIFF
--- a/template/native/convert.go
+++ b/template/native/convert.go
@@ -9,7 +9,7 @@ import (
 // convertPlatformVars takes the platform injected variables
 // within the step environment block and modifies them to be returned
 // within the template.
-func convertPlatformVars(slice raw.StringSliceMap) raw.StringSliceMap {
+func convertPlatformVars(slice raw.StringSliceMap, name string) raw.StringSliceMap {
 	envs := make(map[string]string)
 	for key, value := range slice {
 		key = strings.ToLower(key)
@@ -17,6 +17,8 @@ func convertPlatformVars(slice raw.StringSliceMap) raw.StringSliceMap {
 			envs[strings.TrimPrefix(key, "vela_")] = value
 		}
 	}
+
+	envs["template_name"] = name
 
 	return envs
 }

--- a/template/native/convert_test.go
+++ b/template/native/convert_test.go
@@ -9,34 +9,37 @@ import (
 
 func Test_convertPlatformVars(t *testing.T) {
 	tests := []struct {
-		name string
-		args raw.StringSliceMap
-		want raw.StringSliceMap
+		name         string
+		slice        raw.StringSliceMap
+		templateName string
+		want         raw.StringSliceMap
 	}{
 		{
 			name: "with all vela prefixed vars",
-			args: raw.StringSliceMap{
+			slice: raw.StringSliceMap{
 				"VELA_BUILD_AUTHOR":   "octocat",
 				"VELA_REPO_FULL_NAME": "go-vela/hello-world",
 				"VELA_USER_ADMIN":     "true",
 				"VELA_WORKSPACE":      "/vela/src/github.com/go-vela/hello-world",
 			},
-			want: raw.StringSliceMap{"build_author": "octocat", "repo_full_name": "go-vela/hello-world", "user_admin": "true", "workspace": "/vela/src/github.com/go-vela/hello-world"},
+			templateName: "foo",
+			want:         raw.StringSliceMap{"build_author": "octocat", "repo_full_name": "go-vela/hello-world", "user_admin": "true", "workspace": "/vela/src/github.com/go-vela/hello-world", "template_name": "foo"},
 		},
 		{
 			name: "with combination of vela and user vars",
-			args: raw.StringSliceMap{
+			slice: raw.StringSliceMap{
 				"VELA_BUILD_AUTHOR":   "octocat",
 				"VELA_REPO_FULL_NAME": "go-vela/hello-world",
 				"FOO_VAR1":            "test1",
 				"BAR_VAR1":            "test2",
 			},
-			want: raw.StringSliceMap{"build_author": "octocat", "repo_full_name": "go-vela/hello-world"},
+			templateName: "foo",
+			want:         raw.StringSliceMap{"build_author": "octocat", "repo_full_name": "go-vela/hello-world", "template_name": "foo"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := convertPlatformVars(tt.args); !reflect.DeepEqual(got, tt.want) {
+			if got := convertPlatformVars(tt.slice, tt.templateName); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("convertPlatformVars() = %v, want %v", got, tt.want)
 			}
 		})

--- a/template/native/render.go
+++ b/template/native/render.go
@@ -18,7 +18,7 @@ func Render(tmpl string, s *types.Step) (types.StepSlice, types.SecretSlice, typ
 	buffer := new(bytes.Buffer)
 	config := new(types.Build)
 
-	velaFuncs := funcHandler{envs: convertPlatformVars(s.Environment)}
+	velaFuncs := funcHandler{envs: convertPlatformVars(s.Environment, s.Name)}
 	templateFuncMap := map[string]interface{}{
 		"vela": velaFuncs.returnPlatformVar,
 	}

--- a/template/starlark/convert.go
+++ b/template/starlark/convert.go
@@ -45,7 +45,7 @@ func convertTemplateVars(m map[string]interface{}) (*starlark.Dict, error) {
 //
 // Explanation of type "starlark.StringDict":
 // https://pkg.go.dev/go.starlark.net/starlark#StringDict
-func convertPlatformVars(slice raw.StringSliceMap) (*starlark.Dict, error) {
+func convertPlatformVars(slice raw.StringSliceMap, name string) (*starlark.Dict, error) {
 	build := starlark.NewDict(0)
 	repo := starlark.NewDict(0)
 	user := starlark.NewDict(0)
@@ -65,6 +65,11 @@ func convertPlatformVars(slice raw.StringSliceMap) (*starlark.Dict, error) {
 		return nil, err
 	}
 	err = dict.SetKey(starlark.String("system"), system)
+	if err != nil {
+		return nil, err
+	}
+
+	err = system.SetKey(starlark.String("template_name"), starlark.String(name))
 	if err != nil {
 		return nil, err
 	}

--- a/template/starlark/convert_test.go
+++ b/template/starlark/convert_test.go
@@ -98,7 +98,11 @@ func TestStarlark_Render_velaEnvironmentData(t *testing.T) {
 		t.Error(err)
 	}
 
-	system := starlark.NewDict(1)
+	system := starlark.NewDict(2)
+	err = system.SetKey(starlark.String("template_name"), starlark.String("foo"))
+	if err != nil {
+		t.Error(err)
+	}
 	err = system.SetKey(starlark.String("workspace"), starlark.String("/vela/src/github.com/go-vela/hello-world"))
 	if err != nil {
 		t.Error(err)
@@ -123,25 +127,27 @@ func TestStarlark_Render_velaEnvironmentData(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    raw.StringSliceMap
-		want    *starlark.Dict
-		wantErr bool
+		name         string
+		slice        raw.StringSliceMap
+		templateName string
+		want         *starlark.Dict
+		wantErr      bool
 	}{
 		{
 			name: "with all vela prefixed var",
-			args: raw.StringSliceMap{
+			slice: raw.StringSliceMap{
 				"VELA_BUILD_AUTHOR":   "octocat",
 				"VELA_REPO_FULL_NAME": "go-vela/hello-world",
 				"VELA_USER_ADMIN":     "true",
 				"VELA_WORKSPACE":      "/vela/src/github.com/go-vela/hello-world",
 			},
-			want: withAllPre,
+			templateName: "foo",
+			want:         withAllPre,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := convertPlatformVars(tt.args)
+			got, err := convertPlatformVars(tt.slice, tt.templateName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("convertPlatformVars() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/template/starlark/render.go
+++ b/template/starlark/render.go
@@ -65,7 +65,7 @@ func Render(tmpl string, s *types.Step) (types.StepSlice, types.SecretSlice, typ
 	}
 
 	// load the platform provided vars into a starlark type
-	velaVars, err := convertPlatformVars(s.Environment)
+	velaVars, err := convertPlatformVars(s.Environment, s.Name)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
This change enables the template to determine the name it was originally referenced with. Example:

```yaml
version: "1"
templates:
  - name: sample
    source: github.com/<org>/<repo>/path/to/file/<template>.yml
    type: github

steps:
  - name: sample
    template:
      name: sample
```

```yaml
metadata:
  template: true

steps:
  - name: echo
    commands:
      - echo {{ vela "VELA_TEMPLATE_NAME" }}
    image: alpine
    pull: always
    ruleset:
      event: [ push, pull_request ]
```

Which would return the rendered configuration of:

```yaml
version: "1"
steps:
  - name: sample_echo
    commands:
      - echo sample
    image: alpine
    pull: always
    ruleset:
      event: [ push, pull_request ]
```

closes https://github.com/go-vela/community/issues/284