### PR TITLE
Adds the ability to include templates from local files in .vela.yml 

### DIFF
--- a/compiler/native/expand_test.go
+++ b/compiler/native/expand_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 
@@ -670,9 +671,36 @@ func TestFetchFromGithub(t *testing.T) {
 
 	// run test
 	compiler, _ := New(c)
-	result, err := compiler.fetchGithubTemplate(tmpl)
+	result, err := compiler.fetchGithubTemplate(&tmpl)
 
 	assert.Nil(err)
 	assert.Equal(want, string(result))
+
+}
+
+func TestFetchFromFile(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("github-driver", true, "doc")
+	set.String("github-token", "", "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	tmpl := yaml.Template{
+		Name:   "go",
+		Source: "testdata/template.yml",
+		Format: "native",
+		Type:   "file",
+	}
+
+	want, _ := os.ReadFile("testdata/template.yml")
+
+	// run test
+	compiler, _ := New(c)
+	result, err := compiler.fetchFileTemplate(&tmpl)
+
+	assert.Nil(err)
+	assert.Equal(string(want), string(result))
 
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.6.1
 	github.com/ugorji/go v1.1.11 // indirect
 	github.com/urfave/cli/v2 v2.3.0
 	go.starlark.net v0.0.0-20210602144842-1cdb82c9e17a


### PR DESCRIPTION
Adds switch on tmpl.Type to call the original code and load a template from github or to call new code to read the template from the local filesystem.

Addresses Issue #323