### PR TITLE
refactor(parse): combine pipeline_type logic into parse func

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -14,12 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-vela/compiler/template/native"
-	"github.com/go-vela/compiler/template/starlark"
-
 	yml "github.com/buildkite/yaml"
 
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"
@@ -45,31 +41,9 @@ type ModifyResponse struct {
 //
 // nolint: gocyclo,funlen // ignore function length due to comments
 func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
-	var p *yaml.Build
-
-	parsedRaw, err := c.ParseRaw(v)
+	p, err := c.Parse(v)
 	if err != nil {
 		return nil, err
-	}
-
-	switch c.repo.GetPipelineType() {
-	case constants.PipelineTypeGo:
-		// expand the base configuration
-		p, err = native.RenderBuild(parsedRaw, c.EnvironmentBuild())
-		if err != nil {
-			return nil, err
-		}
-	case constants.PipelineTypeStarlark:
-		// expand the base configuration
-		p, err = starlark.RenderBuild(parsedRaw, c.EnvironmentBuild())
-		if err != nil {
-			return nil, err
-		}
-	default:
-		p, err = c.Parse(parsedRaw)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// validate the yaml configuration

--- a/compiler/native/parse.go
+++ b/compiler/native/parse.go
@@ -89,6 +89,7 @@ func (c *client) Parse(v interface{}) (*types.Build, error) {
 			return nil, fmt.Errorf("unable to parse yaml: unrecognized type %T", v)
 		}
 	default:
+		// nolint:lll // detailed error message
 		return nil, fmt.Errorf("unable to parse config: unrecognized pipeline_type of %s", c.repo.GetPipelineType())
 	}
 

--- a/compiler/native/parse.go
+++ b/compiler/native/parse.go
@@ -67,9 +67,7 @@ func (c *client) Parse(v interface{}) (*types.Build, error) {
 		if err != nil {
 			return nil, err
 		}
-	case constants.PipelineTypeYAML:
-		fallthrough
-	default:
+	case constants.PipelineTypeYAML, "":
 		switch v := v.(type) {
 		case []byte:
 			return ParseBytes(v)
@@ -90,6 +88,8 @@ func (c *client) Parse(v interface{}) (*types.Build, error) {
 		default:
 			return nil, fmt.Errorf("unable to parse yaml: unrecognized type %T", v)
 		}
+	default:
+		return nil, fmt.Errorf("unable to parse config: unrecognized pipeline_type of %s", c.repo.GetPipelineType())
 	}
 
 	return p, nil

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -868,6 +868,7 @@ func Test_client_Parse(t *testing.T) {
 		{"starlark", args{pipelineType: constants.PipelineTypeStarlark, file: "testdata/pipeline_type.star"}, want, false},
 		{"go", args{pipelineType: constants.PipelineTypeGo, file: "testdata/pipeline_type_go.yml"}, want, false},
 		{"empty", args{pipelineType: "", file: "testdata/pipeline_type_default.yml"}, want, false},
+		{"nil", args{pipelineType: "nil", file: "testdata/pipeline_type_default.yml"}, want, false},
 		{"invalid", args{pipelineType: "foo", file: "testdata/pipeline_type_default.yml"}, nil, true},
 	}
 	for _, tt := range tests {
@@ -877,9 +878,15 @@ func Test_client_Parse(t *testing.T) {
 				t.Errorf("Reading file returned err: %v", err)
 			}
 
-			c := &client{
-				repo: &library.Repo{PipelineType: &tt.args.pipelineType},
+			var c *client
+			if tt.args.pipelineType == "nil" {
+				c = &client{}
+			} else {
+				c = &client{
+					repo: &library.Repo{PipelineType: &tt.args.pipelineType},
+				}
 			}
+
 			got, err := c.Parse(content)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -831,7 +831,7 @@ func (FailReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("this is a reader that fails when you try to read")
 }
 
-func Test_client_ParseRaw_File(t *testing.T) {
+func Test_client_ParseRaw(t *testing.T) {
 	expected, err := ioutil.ReadFile("testdata/metadata.yml")
 	if err != nil {
 		t.Errorf("Reading file returned err: %v", err)

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -8,12 +8,13 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
 
 	"github.com/go-vela/types/raw"
 	"github.com/go-vela/types/yaml"


### PR DESCRIPTION
Update `Parse` function to handle `pipeline_type` logic to address feedback from https://github.com/go-vela/server/pull/444#discussion_r677541790.