### PR TITLE
feat(render): support load in starlark templates

### DIFF
--- a/template/starlark/render_test.go
+++ b/template/starlark/render_test.go
@@ -27,6 +27,7 @@ func TestStarlark_RenderStep(t *testing.T) {
 	}{
 		{"basic", args{velaFile: "testdata/step/basic/step.yml", starlarkFile: "testdata/step/basic/template.py"}, "testdata/step/basic/want.yml", false},
 		{"with method", args{velaFile: "testdata/step/with_method/step.yml", starlarkFile: "testdata/step/with_method/template.star"}, "testdata/step/with_method/want.yml", false},
+		{"with module", args{velaFile: "testdata/step/with_module/step.yml", starlarkFile: "testdata/step/with_module/template.star"}, "testdata/step/with_module/want.yml", false},
 		{"user vars", args{velaFile: "testdata/step/with_vars/step.yml", starlarkFile: "testdata/step/with_vars/template.star"}, "testdata/step/with_vars/want.yml", false},
 		{"platform vars", args{velaFile: "testdata/step/with_vars_plat/step.yml", starlarkFile: "testdata/step/with_vars_plat/template.star"}, "testdata/step/with_vars_plat/want.yml", false},
 		{"cancel due to complexity", args{velaFile: "testdata/step/cancel/step.yml", starlarkFile: "testdata/step/cancel/template.star"}, "", true},

--- a/template/starlark/testdata/step/with_module/foo_module.star
+++ b/template/starlark/testdata/step/with_module/foo_module.star
@@ -1,0 +1,11 @@
+
+_foo_var = "module_foo"
+
+def _bar_method():
+    return "module_bar"
+
+foo = module(
+    "foo",
+    foo = _foo_var,
+    bar = _bar_method,
+)

--- a/template/starlark/testdata/step/with_module/step.yml
+++ b/template/starlark/testdata/step/with_module/step.yml
@@ -1,0 +1,7 @@
+steps:
+  - name: sample
+    template:  
+      name: echo
+      vars:
+        image: golang:latest
+        pull_policy: "pull: true"

--- a/template/starlark/testdata/step/with_module/template.star
+++ b/template/starlark/testdata/step/with_module/template.star
@@ -1,0 +1,21 @@
+load("testdata/step/with_module/foo_module.star", "foo")
+
+def main(ctx):
+    return {
+        'version': '1',
+        'steps': [
+            {
+                "name": "build_%s" % foo.foo,
+                "image": "alpine:latest",
+                'commands': [
+                    "echo %s" % foo.foo
+                ]
+            }, {
+                "name": "build_%s" % foo.bar(),
+                "image": "alpine:latest",
+                'commands': [
+                    "echo %s" % foo.bar()
+                ]
+            }
+        ],
+    }

--- a/template/starlark/testdata/step/with_module/want.yml
+++ b/template/starlark/testdata/step/with_module/want.yml
@@ -1,0 +1,11 @@
+version: 1
+steps:
+  - name: sample_build_module_foo
+    image: alpine:latest
+    commands:
+      - echo module_foo
+
+  - name: sample_build_module_bar
+    image: alpine:latest
+    commands:
+      - echo module_bar


### PR DESCRIPTION
_WIP: to get initial feedback before spending too much time on this._

`go-starlark` module [supports](https://github.com/google/starlark-go/blob/master/doc/spec.md#load-statements) the loading of "extensions"/modules via a provided `load` method, as `bazel` does. A `load` method would need to be provided in order to resolve and load the modules.

This would potentially allow for better code reuse across templates. As it stands, creating templates that default steps and configuration, will potentially contain a lot of duplicated steps and step logic, whereas providing the ability to encapsulate this logic into something that's reusable would make templates that rely on conventions to be dried up quite a bit. It also has the potential benefit of making the build logic more readable by allowing templates to be written using top level concepts and hiding the details of how they're configured inside the module(s).

Some questions to start the conversation:
* Do you hate it and is it a hard _"NO!"_?
  * Obviously the answer to this one dictates whether it's worth reading/answering the rest 😄 
* This currently does nothing to fetch the "module" files. The thinking is that the onus would be on the client to ensure that any referenced modules would be available at render time.
  * Is this even possible? Would it be required that these files be available prior to when the step is rendered or could a previous step fetch/move them before they were required?
* Should it allow for recursive module loading and have caching and cycle detection?
* Should this logic live in a separate file (`loader.go`)?
* Any need for namespacing or reserving a namespace?
* Are there more integrated tests that I can write?

_An example where reuse would be beneficial could be something like having build templates that only slightly differ but mostly use the same steps. The actual steps could be reused across templates that were tailored to the specific use-case._

```python
# build_lib.star
load("build_cache.star", "cache")
load("git.star", "git")
load("gradle.star", "gradle")

def main(ctx):
    pipeline = {
        "version": "1",
        "steps":
             pull_request(ctx) +
             push(ctx)
    }
    return pipeline


def pull_request(ctx):
    ctx["event"] = "pull_request"
    return [
        cache.restore(ctx),
        gradle.download_deps(ctx),
        git.fetch_tags(ctx),
        gradle.test(ctx),
    ]


def on_push(ctx):
    ctx["event"] = "push"
    return [
        cache.flush_restore(ctx),
        gradle.download_deps(ctx),
        cache.rebuild(ctx),
        git.fetch_tags(ctx),
        gradle.test(ctx),
        gradle.publish(ctx),
        git.tag(ctx),
    ]
```
